### PR TITLE
Plugin search path

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -84,6 +84,7 @@ else()
 endif()
 
 set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} -DMinVR_DEBUG")
+add_definitions(-DINSTALLPATH="${CMAKE_INSTALL_PREFIX}")
 
 make_directory(${CMAKE_BINARY_DIR}/lib)
 make_directory(${CMAKE_BINARY_DIR}/bin)

--- a/src/display/VRGraphicsWindowNode.cpp
+++ b/src/display/VRGraphicsWindowNode.cpp
@@ -108,7 +108,7 @@ VRDisplayNode* VRGraphicsWindowNode::create(VRMainInterface *vrMain, VRDataIndex
 	settings.debugContext = int(config->getValue("UseDebugContext", nameSpace));
 	settings.msaaSamples = int(config->getValue("MSAASamples", nameSpace));
 
-	std::cout << settings.xpos << ", " << settings.ypos << ", " << settings.width << ", " << settings.height << std::endl;
+	//std::cout << settings.xpos << ", " << settings.ypos << ", " << settings.width << ", " << settings.height << std::endl;
 	VRDisplayNode *node = new VRGraphicsWindowNode(nameSpace, gfxToolkit, winToolkit, settings);
 
 	return node;

--- a/src/main/VRAppLauncher.h
+++ b/src/main/VRAppLauncher.h
@@ -13,12 +13,22 @@
 
 namespace MinVR {
 
+/** VRAppLauncher allows applications to customize how they would like to fork a MinVR application.
+	This is important for both ssh and windows forking as well as specialized ways for launching
+	an application.  For example, perhaps a plugin requires loading another application first or
+	an application is interpreted (i.e. running a python script).*/
 class VRAppLauncher {
 public:
 	virtual ~VRAppLauncher() {}
 
+	/// Returns the command line to call when forking an application.  The initString, which contains
+	/// MinVR specific items will be provided.  This string needs to be passed through the command line somehow.
+	/// For example, the initString may be it's own parameter (i.e. MINVR_STR=<initString>)
 	virtual std::string generateCommandLine(const std::string& initString) const = 0;
+	/// An App Launcher both knows how to interpret a command line and how to create one.  getInitString() will return
+	/// the initString that comes in through the command line.  (i.e. it knows how to parse MINVR_STR=<initString>)
 	virtual const std::string& getInitString() const = 0;
+	/// Returns the full path to the executable (usually the first command line parameter)
 	virtual const std::string& getExecutable() const = 0;
 };
 

--- a/src/main/VRAppLauncher.h
+++ b/src/main/VRAppLauncher.h
@@ -19,6 +19,7 @@ public:
 
 	virtual std::string generateCommandLine(const std::string& initString) const = 0;
 	virtual const std::string& getInitString() const = 0;
+	virtual const std::string& getExecutable() const = 0;
 };
 
 

--- a/src/main/VRMain.cpp
+++ b/src/main/VRMain.cpp
@@ -145,10 +145,10 @@ VRMain::initialize(int argc, char** argv)
 	initialize(launcher);
 }
 
-void VRMain::initialize(int argc, char **argv, const std::string& configFile, std::vector<std::string> args) {
+void VRMain::initialize(int argc, char **argv, const std::string& configFile, std::vector<std::string> dataIndexOverrides) {
 	std::string initStr = configFile;
-	for (int f = 0; f < args.size(); f++) {
-		initStr = initStr + " " + args[f];
+	for (int f = 0; f < dataIndexOverrides.size(); f++) {
+		initStr = initStr + " " + dataIndexOverrides[f];
 	}
 
 	VRDefaultAppLauncher launcher(argc, argv, initStr);
@@ -335,6 +335,20 @@ void VRMain::initialize(const VRAppLauncher& launcher) {
 
 	// Load plugins from the plugin directory.  This will add their factories to the master VRFactory.
 	{
+
+		// MinVR will try to load plugins based on a search path.  If it doesn't find the plugin
+		// in one path, it will look in another supplied path.  To specify custom paths for an application
+		// a user can set vrmain->addPLuginSearchPath(mypath);
+		//
+		// Here is the search path order that MinVR searches for plugins:
+		//
+		//    1. Plugin path specified in config ("/PluginPath" in VRDataIndex)
+		//    2. Working directory (".")
+		//    3. <Working directory>/plugins ("./plugins")
+		//    4. Custom user defined paths (i.e. vrmain->addPluginSearchPath(mypath))
+		//    5. <Binary directory>/../plugins ("build/bin/../plugins")
+		//    6. <Install directory>/plugins ("install/plugins")
+		//    7. <$MINVR_ROOT>/plugins ("$MINVR_ROOT/plugins")
 
 		std::list<std::string> names = _config->selectByAttribute("pluginType", "*", _name);
 		for (std::list<std::string>::const_iterator it = names.begin(); it != names.end(); it++) {

--- a/src/main/VRMain.cpp
+++ b/src/main/VRMain.cpp
@@ -345,6 +345,9 @@ void VRMain::initialize(const VRAppLauncher& launcher) {
 			}
 			pluginSearchPaths.push_back(".");
 			pluginSearchPaths.push_back("./plugins");
+			for (int f = 0; f < _pluginSearchPaths.size(); f++) {
+				pluginSearchPaths.push_back(_pluginSearchPaths[f]);
+			}
 			std::size_t endPos = launcher.getExecutable().find_last_of("/\\");
 			std::string execPath = endPos != std::string::npos ? launcher.getExecutable().substr(0,endPos) : ".";
 			pluginSearchPaths.push_back(execPath + "/../plugins");
@@ -352,10 +355,6 @@ void VRMain::initialize(const VRAppLauncher& launcher) {
 			const char* minvrRoot = std::getenv("MINVR_ROOT");
 			if (minvrRoot) {
 				pluginSearchPaths.push_back(std::string(minvrRoot) + "/plugins");
-			}
-
-			for (int f = 0; f < _pluginSearchPaths.size(); f++) {
-				pluginSearchPaths.push_back(_pluginSearchPaths[f]);
 			}
 
 			bool found = false;

--- a/src/main/VRMain.cpp
+++ b/src/main/VRMain.cpp
@@ -20,6 +20,7 @@
 #include <plugin/VRPluginManager.h>
 #include <sstream>
 #include <main/impl/VRDefaultAppLauncher.h>
+#include <cstdlib>
 
 namespace MinVR {
 
@@ -348,6 +349,10 @@ void VRMain::initialize(const VRAppLauncher& launcher) {
 			std::string execPath = endPos != std::string::npos ? launcher.getExecutable().substr(0,endPos) : ".";
 			pluginSearchPaths.push_back(execPath + "/../plugins");
 			pluginSearchPaths.push_back(std::string(INSTALLPATH) + "/plugins");
+			const char* minvrRoot = std::getenv("MINVR_ROOT");
+			if (minvrRoot) {
+				pluginSearchPaths.push_back(std::string(minvrRoot) + "/plugins");
+			}
 
 			for (int f = 0; f < _pluginSearchPaths.size(); f++) {
 				pluginSearchPaths.push_back(_pluginSearchPaths[f]);

--- a/src/main/VRMain.h
+++ b/src/main/VRMain.h
@@ -63,7 +63,14 @@ public:
   /// create a new process (on windows systems) as necessary so that each vrsetup
   /// has its own process.
   void initialize(int argc, char **argv);
-  void initialize(int argc, char **argv, const std::string& configFile, std::vector<std::string> args = std::vector<std::string>());
+  /// If a user wants more control of the command line, this initialize method is the one
+  /// that should be used.  Here a user can provide any set of command line arguments in any order.
+  /// The only required item that also needs to be passed is the configFile path.  Optionally, a
+  /// user can also provide data index overrides in the format "/path/to/item=value".
+  void initialize(int argc, char **argv, const std::string& configFile, std::vector<std::string> dataIndexOverrides = std::vector<std::string>());
+  /// If a user wants to control everything about the command line including how MinVR parameters
+  /// are passed to forked processes, this initialize method should be used.  This is a more advanced
+  /// feature and a user should refer to VRAppLauncher and the default implementation in VRDefaultAppLauncher
   void initialize(const VRAppLauncher& launcher);
   
 

--- a/src/main/VRMain.h
+++ b/src/main/VRMain.h
@@ -106,6 +106,9 @@ public:
  
   VRGraphicsToolkit* getGraphicsToolkit(const std::string &name);
   VRWindowToolkit* getWindowToolkit(const std::string &name);
+  void addPluginSearchPath(const std::string& path) {
+
+  }
    
 private:
 
@@ -125,6 +128,7 @@ private:
   std::vector<VRGraphicsToolkit*> _gfxToolkits;
   std::vector<VRWindowToolkit*>   _winToolkits;
   std::vector<VRDisplayNode*>     _displayGraphs;
+  std::vector<std::string> _pluginSearchPaths;
 
   int _frame;
 };

--- a/src/main/VRMainInterface.h
+++ b/src/main/VRMainInterface.h
@@ -29,6 +29,7 @@ public:
   virtual VRGraphicsToolkit* getGraphicsToolkit(const std::string &name) = 0;  
   virtual VRWindowToolkit* getWindowToolkit(const std::string &name) = 0;
   virtual VRFactory* getFactory() = 0;
+  virtual void addPluginSearchPath(const std::string& path) = 0;
 };
 
 

--- a/src/main/impl/VRDefaultAppLauncher.h
+++ b/src/main/impl/VRDefaultAppLauncher.h
@@ -28,6 +28,10 @@ public:
 		return initString;
 	}
 
+	const std::string& getExecutable() const {
+		return program;
+	}
+
 private:
 	std::string program;
 	std::string cmd;

--- a/src/main/impl/VRDefaultAppLauncher.h
+++ b/src/main/impl/VRDefaultAppLauncher.h
@@ -13,6 +13,10 @@
 
 namespace MinVR {
 
+/** VRDefaultAppLauncher sends the MinVR initString through a command line parameter named
+ 	MINVR_DATA after encoding it into a base64 string.  The reason for the encoding is so
+ 	that it is easy to send a simple string as an argument and decoding when a fork is launched.
+ */
 class VRDefaultAppLauncher : public VRAppLauncher {
 public:
 	VRDefaultAppLauncher(int argc, char** argv, const std::string& customInitString = "");

--- a/src/plugin/VRPluginManager.cpp
+++ b/src/plugin/VRPluginManager.cpp
@@ -87,7 +87,8 @@ bool VRPluginManager::loadPlugin(const std::string& pluginFilePath) {
 		version_t* getVersion = lib->loadSymbol<version_t>("getPluginFrameworkVersion");
 		if (getVersion() != getPluginFrameworkVersion())
 		{
-			std::cout << "Cannot load plugin: " << pluginFilePath << " - Incorrect framework version." << std::endl;
+			//std::cerr << "Cannot load plugin: " << pluginFilePath << " - Incorrect framework version." << std::endl;
+			delete lib;
 			return false;
 		}
 
@@ -95,7 +96,8 @@ bool VRPluginManager::loadPlugin(const std::string& pluginFilePath) {
 		create_t* createVRPlugin = lib->loadSymbol<create_t>("createPlugin");
 		if (createVRPlugin == NULL)
 		{
-			std::cout << "Cannot load plugin: " << pluginFilePath << " - createVRPlugin funciton not found." << std::endl;
+			//std::cerr << "Cannot load plugin: " << pluginFilePath << " - createVRPlugin funciton not found." << std::endl;
+			delete lib;
 			return false;
 		}
 
@@ -107,6 +109,9 @@ bool VRPluginManager::loadPlugin(const std::string& pluginFilePath) {
 		_libraries.push_back(lib);
 
 		return true;
+	}
+	else {
+		delete lib;
 	}
 
 	return false;

--- a/src/plugin/VRSharedLibrary.cpp
+++ b/src/plugin/VRSharedLibrary.cpp
@@ -70,7 +70,7 @@ void VRSharedLibrary::load() {
 
 		if (!_lib) {
 			//MinVR::Logger::getInstance().assertMessage(false, "Could not load library: " + _filePath + " - " + error);
-			std::cout << "Could not load library: " + _filePath + " - " + error << std::endl;
+			//std::cerr << "Could not load library: " + _filePath + " - " + error << std::endl;
 			return;
 		}
 


### PR DESCRIPTION
I finally got around to fixing #68.  Here is the current search logic:

1. Plugin path specified in config
2. Working directory
3. (Working directory)/plugins
4. Custom user defined paths (i.e. ```vrmain->addPluginSearchPath(mypath)```)
5. (Binary directory)/../plugins
6. (Install directory)/plugins
7. ($MINVR_ROOT)/plugins

Now you can call the SimpleOpenGL application any directory:
```bash
cd MinVR2
build/bin/SimpleOpenGL examples/SimpleOpenGL/desktop.xml
```