### PR TITLE
VRDataIndex should not allow names without namespaces

### DIFF
--- a/plugins/OpenVR/src/VROpenVRNode.cpp
+++ b/plugins/OpenVR/src/VROpenVRNode.cpp
@@ -125,8 +125,8 @@ VROpenVRNode::render(VRDataIndex *renderState, VRRenderHandler *renderHandler)
 	glClear( GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT );
 
 	VRMatrix4 view_left = m_mat4eyePosLeft * head_pose;
-	renderState->addData("ProjectionMatrix", m_mat4ProjectionLeft);
-	renderState->addData("ViewMatrix", view_left);
+	renderState->addData("/ProjectionMatrix", m_mat4ProjectionLeft);
+	renderState->addData("/ViewMatrix", view_left);
 
 	if (_children.size() == 0) {
 		renderHandler->onVRRenderScene(renderState, this);
@@ -156,8 +156,8 @@ VROpenVRNode::render(VRDataIndex *renderState, VRRenderHandler *renderHandler)
 
 	VRMatrix4 view_right = m_mat4eyePosRight * head_pose;
 	
-	renderState->addData("ProjectionMatrix",m_mat4ProjectionRight);
-	renderState->addData("ViewMatrix", view_right);
+	renderState->addData("/ProjectionMatrix",m_mat4ProjectionRight);
+	renderState->addData("/ViewMatrix", view_right);
 
 	if (_children.size() == 0) {
 		renderHandler->onVRRenderScene(renderState, this);

--- a/plugins/Scalable/src/VRScalableNode.cpp
+++ b/plugins/Scalable/src/VRScalableNode.cpp
@@ -71,7 +71,7 @@ VRScalableNode::render(VRDataIndex *renderState, VRRenderHandler *renderHandler)
 	double t = near*tan(DEGTORAD*Frustum.TopAngle);
 	
 	VRMatrix4 projMat = VRMatrix4::projection(l, r, b, t, near, far);
-	renderState->addData("ProjectionMatrix", projMat);
+	renderState->addData("/ProjectionMatrix", projMat);
 	
 	VRMatrix4 rotZ = VRMatrix4::rotationZ(DEGTORAD*Frustum.ViewAngleA);
 	VRMatrix4 rotY = VRMatrix4::rotationY(DEGTORAD*Frustum.ViewAngleB);
@@ -79,7 +79,7 @@ VRScalableNode::render(VRDataIndex *renderState, VRRenderHandler *renderHandler)
 	VRMatrix4 Mtrans = VRMatrix4::translation(VRPoint3(0, 0, 0) - pe);
 	VRMatrix4 viewMat = rotZ * rotY * rotX * Mtrans;
 
-	renderState->addData("ViewMatrix", viewMat);
+	renderState->addData("/ViewMatrix", viewMat);
 
 	VRDisplayNode::render(renderState, renderHandler);
 	

--- a/src/config/VRDataIndex.cpp
+++ b/src/config/VRDataIndex.cpp
@@ -716,7 +716,15 @@ std::string VRDataIndex::getName(const std::string valName,
 
 // Returns the data object for this name.
 VRDatumPtr VRDataIndex::getDatum(const std::string valName) {
-  VRDataMap::const_iterator p = mindex.find(valName);
+  // If there is no namespace specified, assume the root space.  Note that this is
+  // seldom what is really wanted, so it's better to try to use namespaces well.
+  std::string testName;
+  if (valName[0] != '/')
+    testName = "/" + valName;
+  else
+    testName = valName;
+  
+  VRDataMap::const_iterator p = mindex.find(testName);
 
   if (p == mindex.end()) {
     throw std::runtime_error("Never heard of " + valName);

--- a/src/config/VRDataIndex.cpp
+++ b/src/config/VRDataIndex.cpp
@@ -973,9 +973,7 @@ std::string VRDataIndex::addData(const std::string valName,
   // All names must be in some namespace. If there is no namespace, put this
   // into the root namespace.
   std::string fixedValName = valName;
-  if (valName[0] != '/') {
-    fixedValName = std::string("/") + valName;
-  }
+  if (valName[0] != '/') fixedValName = std::string("/") + valName;
   
   // Check if the name is already in use.
   VRDataMap::iterator it = mindex.find(fixedValName);

--- a/src/config/VRDataIndex.cpp
+++ b/src/config/VRDataIndex.cpp
@@ -970,19 +970,26 @@ std::string VRDataIndex::addData(const std::string valName,
   if (valName.compare("/") == 0)
     throw std::runtime_error(std::string("cannot replace the root namespace"));
 
+  // All names must be in some namespace. If there is no namespace, put this
+  // into the root namespace.
+  std::string fixedValName = valName;
+  if (valName[0] != '/') {
+    fixedValName = std::string("/") + valName;
+  }
+  
   // Check if the name is already in use.
-  VRDataMap::iterator it = mindex.find(valName);
+  VRDataMap::iterator it = mindex.find(fixedValName);
   if (it == mindex.end()) {
 
     // No.  Create a new object.
     VRDatumPtr obj = factory.CreateVRDatum(VRCORETYPE_CONTAINER, &value);
     //std::cout << "added " << obj.containerVal()->getDatum() << std::endl;
-    mindex.insert(VRDataMap::value_type(valName, obj));
+    mindex.insert(VRDataMap::value_type(fixedValName, obj));
 
     // Add this value to the parent container, if any.
     VRContainer cValue;
-    cValue.push_back(getTrimName(valName));
-    std::string ns = getNameSpace(valName);
+    cValue.push_back(getTrimName(fixedValName));
+    std::string ns = getNameSpace(fixedValName);
     // The parent container is the namespace minus the trailing /.
     if (ns.compare("/") != 0) addData(ns.substr(0,ns.size() - 1), cValue);
     
@@ -990,7 +997,7 @@ std::string VRDataIndex::addData(const std::string valName,
     // Add value to existing container.
     it->second.containerVal()->addToValue(value);
   }
-  return valName;
+  return fixedValName;
 }
 
 // Prints the whole index.

--- a/src/config/VRDataIndex.h
+++ b/src/config/VRDataIndex.h
@@ -301,8 +301,13 @@ private:
   template <typename T, const VRCORETYPE_ID TID>
   std::string addDataSpecialized(const std::string valName, T value) {
 
+    // All names must be in some namespace. If there is no namespace,
+    // put this into the root namespace.
+    std::string fixedValName = valName;
+    if (valName[0] != '/') fixedValName = std::string("/") + valName;
+      
     std::pair<VRDataMap::iterator, bool>res =
-      mindex.insert(VRDataMap::value_type(valName, NULL));
+      mindex.insert(VRDataMap::value_type(fixedValName, NULL));
 
     // Was it already used?
     if (res.second) {
@@ -312,8 +317,8 @@ private:
 
       // Add this value to the parent container, if any.
       VRContainer cValue;
-      cValue.push_back(explodeName(valName).back());
-      std::string ns = getNameSpace(valName);
+      cValue.push_back(explodeName(fixedValName).back());
+      std::string ns = getNameSpace(fixedValName);
       // The parent container is the namespace minus the trailing /.
       if (ns.compare("/") != 0) addData(ns.substr(0, ns.size() - 1), cValue);
 
@@ -330,7 +335,7 @@ private:
       }
     }
         
-    return valName;
+    return fixedValName;
   }
 
 

--- a/src/config/VRDataIndex.h
+++ b/src/config/VRDataIndex.h
@@ -537,7 +537,7 @@ public:
 
   // Still another utility, to accommodate the use of environment
   // variables in the file names.  Also potentially useful, so public.
-  std::string dereferenceEnvVars(const std::string fileName);
+  static std::string dereferenceEnvVars(const std::string fileName);
   
   // Mostly just for debug purposes.
   std::string printStructure();

--- a/src/display/VRConsoleNode.cpp
+++ b/src/display/VRConsoleNode.cpp
@@ -24,7 +24,7 @@ void VRConsoleNode::addChild(VRDisplayNode *child) {
 void VRConsoleNode::render(VRDataIndex *renderState, VRRenderHandler *renderHandler) {
 
   renderState->pushState();
-	renderState->addData("IsConsole", 1);
+	renderState->addData("/IsConsole", 1);
 
 	renderHandler->onVRRenderContext(renderState, this);
 	renderHandler->onVRRenderScene(renderState, this);

--- a/src/display/VRConsoleNode.cpp
+++ b/src/display/VRConsoleNode.cpp
@@ -11,6 +11,7 @@
 namespace MinVR {
 
 VRConsoleNode::VRConsoleNode(const std::string &name, std::ostream *stream) : VRDisplayNode(name), m_stream(stream)  {
+  _valuesAdded.push_back("/IsConsole");
 }
 
 VRConsoleNode::~VRConsoleNode() {

--- a/src/display/VRDisplayNode.cpp
+++ b/src/display/VRDisplayNode.cpp
@@ -19,13 +19,14 @@ VRDisplayNode::~VRDisplayNode() {
 	clearChildren(true);
 }
 
-void VRDisplayNode::render(VRDataIndex *renderState, VRRenderHandler *renderHandler) {
-    if (_children.size() > 0) {
-		for (vector<VRDisplayNode*>::iterator it = _children.begin(); it != _children.end(); it++) {
+void VRDisplayNode::render(VRDataIndex *renderState,
+                           VRRenderHandler *renderHandler) {
+  if (_children.size() > 0) {
+		for (vector<VRDisplayNode*>::iterator it = _children.begin();
+         it != _children.end(); it++) {
 			(*it)->render(renderState, renderHandler);
 		}
-	} else
-	{
+	} else {
 		renderHandler->onVRRenderScene(renderState, this);
 	}
 }
@@ -60,17 +61,62 @@ void VRDisplayNode::clearChildren(bool destroyChildren) {
 	_children.clear();
 }
 
-void VRDisplayNode::createChildren(VRMainInterface *vrMain, VRDataIndex *config, const std::string &nameSpace) {
+void VRDisplayNode::createChildren(VRMainInterface *vrMain,
+                                   VRDataIndex *config,
+                                   const std::string &nameSpace) {
+
   std::list<std::string> names = config->getValue(nameSpace);
   std::string validatedNameSpace = config->validateNameSpace(nameSpace);
-  for (std::list<std::string>::const_iterator it = names.begin(); it != names.end(); ++it) {
+
+  for (std::list<std::string>::const_iterator it = names.begin();
+       it != names.end(); ++it) {
+
 	  if (config->exists(*it, validatedNameSpace)){
-		  VRDisplayNode *child = vrMain->getFactory()->create<VRDisplayNode>(vrMain, config, config->validateNameSpace(validatedNameSpace) + *it);
-	  if (child != NULL) {
-		addChild(child);
-	  }
-	}
+		  VRDisplayNode *child =
+        vrMain->getFactory()->create<VRDisplayNode>(vrMain,
+                                                    config,
+                                                    validatedNameSpace + *it);
+      if (child != NULL) {
+        addChild(child);
+      }
+    }
   }	
 }
+
+  
+/// Returns a list of the values added to the render state by this
+/// node, and its children nodes.
+std::map<std::string,std::string> VRDisplayNode::getValuesAdded() {
+
+  std::map<std::string,std::string> out;
+
+  // Stick the node name with the values added.
+  if (_valuesAdded.size() > 0) {
+    for (std::list<std::string>::iterator it = _valuesAdded.begin();
+         it != _valuesAdded.end(); it++) {
+      out[*it] = _name + "(" + getType() + ")";
+    }
+  }
+
+  // Look through all the children nodes, and append their values to
+  // the list, with the current node name on the front.
+  if (_children.size() > 0) {
+		for (vector<VRDisplayNode*>::iterator it = _children.begin();
+         it != _children.end(); it++) {
+
+      std::map<std::string,std::string> childOut = (*it)->getValuesAdded();
+
+      if (childOut.size() > 0) {
+        for (std::map<std::string,std::string>::iterator jt = childOut.begin();
+             jt != childOut.end(); jt++) {
+          out[jt->first] = jt->second;
+        }
+      }
+		}
+	} 
+
+  return out;
+}
+
 
 } /* namespace MinVR */

--- a/src/display/VRDisplayNode.h
+++ b/src/display/VRDisplayNode.h
@@ -17,7 +17,8 @@
 
 namespace MinVR {
 
-/** VRDisplayNode is an abstract base class that can be inherited to create a different types of displays.
+/** VRDisplayNode is an abstract base class that can be inherited to
+    create a different types of displays.
  */
  
 class VRMainInterface;
@@ -26,30 +27,38 @@ class VRDisplayNode {
 public:
 	VRDisplayNode(const std::string &name);
 
-	/// VRDisplayNode assumes that it owns its children, so it will delete its children when destroyed.  If
-	/// this functionality is not desired, create an adapter display node with a weak pointer.
+	/// VRDisplayNode assumes that it owns its children, so it will
+	/// delete its children when destroyed.  If this functionality is
+	/// not desired, create an adapter display node with a weak pointer.
 	virtual ~VRDisplayNode();
 
 	/// Returns the name given to this display node in the config file.
 	virtual std::string getName() { return _name; }
 
-	/// Returns a string describing the type of the node (e.g., VRGroupNode, VRWindowNode)
+	/// Returns a string describing the type of the node (e.g.,
+	/// VRGroupNode, VRWindowNode)
 	virtual std::string getType() = 0;
 
-	/// Calls render function on each of the display node's children.  If there are no children, then we are
-	/// at a leaf node and onVRRenderScene() is called for each render handler.  Some subclasses, such as
-	/// VRGraphicsWindow nodes should override this method and call renderHandler->onVRRenderContext() 
-	/// before calling the children render functions so that the application programmer will have
-	/// a callback at the context level as well as the scene level.
+	/// Calls the render function on each of the display node's
+	/// children.  If there are no children, then we are at a leaf node
+	/// and onVRRenderScene() is called for each render handler.  Some
+	/// subclasses, such as VRGraphicsWindow nodes should override this
+	/// method and call renderHandler->onVRRenderContext() before
+	/// calling the children render functions so that the application
+	/// programmer will have a callback at the context level as well as
+	/// the scene level.
 	virtual void render(VRDataIndex *renderState, VRRenderHandler *renderHandler);
 
-	/// In cases where rendering is asynchronous (e.g., the GPU executes commands in parallel with the CPU), 
-	/// subclasses should implement a way to block during this function until the rendering is complete
-	/// (e.g., call glFinish()).  This is needed to support synchronized rendering on multiple networked nodes.
+	/// In cases where rendering is asynchronous (e.g., the GPU executes
+	/// commands in parallel with the CPU), subclasses should implement
+	/// a way to block during this function until the rendering is
+	/// complete (e.g., call glFinish()).  This is needed to support
+	/// synchronized rendering on multiple networked nodes.
 	virtual void waitForRenderToComplete(VRDataIndex *renderState);
 
-	/// Actually displays the rendered results.  This call should be optimized to be as fast as possible,
-	/// with the majority of the rendering work happening in the render() function.  For graphics 
+	/// Actually displays the rendered results.  This call should be
+	/// optimized to be as fast as possible, with the majority of the
+	/// rendering work happening in the render() function.  For graphics
 	/// displays, the only thing this call should do is swapBuffers.
 	virtual void displayFinishedRendering(VRDataIndex *renderState);
 
@@ -63,13 +72,24 @@ public:
 	void clearChildren(bool destroyChildren = false);
 
 	/// Creates the children of the node
-	virtual void createChildren(VRMainInterface *vrMain, VRDataIndex *config, const std::string &nameSpace);
+	virtual void createChildren(VRMainInterface *vrMain,
+                              VRDataIndex *config,
+                              const std::string &nameSpace);
 
 	static std::string getAttributeName(){ return "displaynodeType"; };
 
+  /// Returns a list of the values added to the render state by this
+  /// node, and its children nodes.
+  virtual std::map<std::string,std::string> getValuesAdded();
+  
 protected:
 	std::vector<VRDisplayNode*> _children;
-    std::string _name;
+  std::string _name;
+  
+  // This contains a list of the values added by this node.  When
+  // getValuesAdded() is invoked, this will be returned, appended to a
+  // list of values added by this node's children.
+  std::list<std::string> _valuesAdded;
 };
 
 }

--- a/src/display/VRGraphicsToolkit.h
+++ b/src/display/VRGraphicsToolkit.h
@@ -13,7 +13,7 @@ namespace MinVR {
  */
 class VRGraphicsToolkit {
 public:
-	~VRGraphicsToolkit() {}
+	virtual ~VRGraphicsToolkit() {}
 
     virtual std::string getName() = 0;
 

--- a/src/display/VRGraphicsWindowNode.cpp
+++ b/src/display/VRGraphicsWindowNode.cpp
@@ -14,6 +14,13 @@ VRGraphicsWindowNode::VRGraphicsWindowNode(const std::string &name, VRGraphicsTo
 	VRDisplayNode(name), _gfxToolkit(gfxToolkit), _winToolkit(winToolkit), _settings(settings)
 {
 	_windowID = _winToolkit->createWindow(_settings);
+  _valuesAdded.push_back("/WindowX");
+  _valuesAdded.push_back("/WindowX");
+  _valuesAdded.push_back("/WindowWidth");
+  _valuesAdded.push_back("/WindowHeight");
+  _valuesAdded.push_back("/SharedContextGroupID");
+  _valuesAdded.push_back("/WindowID");
+
 }
 
 VRGraphicsWindowNode::~VRGraphicsWindowNode() {

--- a/src/display/VRGraphicsWindowNode.cpp
+++ b/src/display/VRGraphicsWindowNode.cpp
@@ -24,12 +24,12 @@ void VRGraphicsWindowNode::render(VRDataIndex *renderState, VRRenderHandler *ren
   renderState->pushState();
 
 	// Is this the kind of state information we expect to pass from one node to the next?
-	renderState->addData("WindowX", _settings.xpos);
-	renderState->addData("WindowY", _settings.ypos);
-	renderState->addData("WindowWidth", _settings.width);
-	renderState->addData("WindowHeight", _settings.height);
-	renderState->addData("SharedContextGroupID", _settings.sharedContextGroupID);
-	renderState->addData("WindowID", _windowID);
+	renderState->addData("/WindowX", _settings.xpos);
+	renderState->addData("/WindowY", _settings.ypos);
+	renderState->addData("/WindowWidth", _settings.width);
+	renderState->addData("/WindowHeight", _settings.height);
+	renderState->addData("/SharedContextGroupID", _settings.sharedContextGroupID);
+	renderState->addData("/WindowID", _windowID);
   
 	_winToolkit->makeWindowCurrent(_windowID);
 	/*if (_settings.quadBuffered)

--- a/src/display/VRGraphicsWindowNode.cpp
+++ b/src/display/VRGraphicsWindowNode.cpp
@@ -108,7 +108,7 @@ VRDisplayNode* VRGraphicsWindowNode::create(VRMainInterface *vrMain, VRDataIndex
 	settings.debugContext = int(config->getValue("UseDebugContext", nameSpace));
 	settings.msaaSamples = int(config->getValue("MSAASamples", nameSpace));
 
-	std::cout << settings.xpos << ", " << settings.ypos << ", " << settings.width << ", " << settings.height << std::endl;
+  //	std::cout << "Window corners: " << settings.xpos << ", " << settings.ypos << ", " << settings.width << ", " << settings.height << std::endl;
 	VRDisplayNode *node = new VRGraphicsWindowNode(nameSpace, gfxToolkit, winToolkit, settings);
 
 	return node;

--- a/src/display/VRLookAtNode.cpp
+++ b/src/display/VRLookAtNode.cpp
@@ -19,7 +19,7 @@ VRLookAtNode::render(VRDataIndex *renderState, VRRenderHandler *renderHandler)
 {
 	renderState->pushState();
 
-	renderState->addData("LookAtMatrix", _lookAtMatrix);
+	renderState->addData("/LookAtMatrix", _lookAtMatrix);
 	VRDisplayNode::render(renderState, renderHandler);
 
 	renderState->popState();

--- a/src/display/VRLookAtNode.cpp
+++ b/src/display/VRLookAtNode.cpp
@@ -4,9 +4,10 @@
 namespace MinVR {
 
 
-	VRLookAtNode::VRLookAtNode(const std::string &name, VRMatrix4 initiallookAtMatrix) :
-		VRDisplayNode(name),_lookAtMatrix(initiallookAtMatrix)
+VRLookAtNode::VRLookAtNode(const std::string &name, VRMatrix4 initiallookAtMatrix) :
+  VRDisplayNode(name),_lookAtMatrix(initiallookAtMatrix)
 {
+  _valuesAdded.push_back("/LookAtMatrix");
 }
 
 VRLookAtNode::~VRLookAtNode()

--- a/src/display/VROffAxisProjectionNode.cpp
+++ b/src/display/VROffAxisProjectionNode.cpp
@@ -54,7 +54,7 @@ VROffAxisProjectionNode::render(VRDataIndex *renderState, VRRenderHandler *rende
 
 	VRMatrix4 projMat = VRMatrix4::projection(l, r, b, t, _nearClip, _farClip);
 
-	renderState->addData("ProjectionMatrix", projMat);
+	renderState->addData("/ProjectionMatrix", projMat);
 
 	// Rotate the projection to be non-perpendicular
 	VRMatrix4 Mrot(vr[0], vr[1], vr[2], 0.0,
@@ -67,7 +67,7 @@ VROffAxisProjectionNode::render(VRDataIndex *renderState, VRRenderHandler *rende
 
 	VRMatrix4 viewMat = Mrot * Mtrans;
 
-	renderState->addData("ViewMatrix", viewMat);
+	renderState->addData("/ViewMatrix", viewMat);
 
 	VRDisplayNode::render(renderState, renderHandler);
 

--- a/src/display/VROffAxisProjectionNode.cpp
+++ b/src/display/VROffAxisProjectionNode.cpp
@@ -7,6 +7,8 @@ namespace MinVR {
 	VROffAxisProjectionNode::VROffAxisProjectionNode(const std::string &name, VRPoint3 topLeft, VRPoint3 botLeft, VRPoint3 topRight, VRPoint3 botRight, double nearClip, double farClip) :
 	VRDisplayNode(name), _topLeft(topLeft), _botLeft(botLeft), _topRight(topRight), _botRight(botRight),  _nearClip(nearClip), _farClip(farClip)
 {
+  _valuesAdded.push_back("/ProjectionMatrix");
+  _valuesAdded.push_back("/ViewMatrix");
 }
 
 VROffAxisProjectionNode::~VROffAxisProjectionNode()
@@ -26,8 +28,8 @@ VROffAxisProjectionNode::render(VRDataIndex *renderState, VRRenderHandler *rende
 	VRPoint3 pb = _botRight;
 	VRPoint3 pc = _topLeft;
 	VRPoint3 pe(0,0,0);
-	if (renderState->exists("LookAtMatrix","/")){
-		VRMatrix4 lookAtMatrix = renderState->getValue("LookAtMatrix");
+	if (renderState->exists("/LookAtMatrix")){
+		VRMatrix4 lookAtMatrix = renderState->getValue("/LookAtMatrix");
 		VRMatrix4 head_frame = lookAtMatrix.inverse();
 		pe = VRPoint3(head_frame[3][0], head_frame[3][1], head_frame[3][2]);
 	}

--- a/src/display/VRStereoNode.cpp
+++ b/src/display/VRStereoNode.cpp
@@ -12,8 +12,11 @@
 
 namespace MinVR {
 
-	VRStereoNode::VRStereoNode(const std::string &name, float interOcularDist, VRGraphicsToolkit *gfxToolkit, VRStereoFormat format) :
-VRDisplayNode(name), _iod(interOcularDist), _gfxToolkit(gfxToolkit), _format(format) {
+VRStereoNode::VRStereoNode(const std::string &name, float interOcularDist, VRGraphicsToolkit *gfxToolkit, VRStereoFormat format) :
+  VRDisplayNode(name), _iod(interOcularDist), _gfxToolkit(gfxToolkit), _format(format) {
+  _valuesAdded.push_back("/StereoFormat");
+  _valuesAdded.push_back("/LookAtMatrix");
+  _valuesAdded.push_back("/Eye");
 }
 
 VRStereoNode::~VRStereoNode() {
@@ -24,13 +27,13 @@ void VRStereoNode::render(VRDataIndex *renderState, VRRenderHandler *renderHandl
   renderState->pushState();
 
 	if (_format == VRSTEREOFORMAT_MONO) {
-		renderState->addData("StereoFormat", "Mono");
+		renderState->addData("/StereoFormat", "Mono");
 	
 		_gfxToolkit->setDrawBuffer(VRGraphicsToolkit::VRDRAWBUFFER_BACK);
 		renderOneEye(renderState, renderHandler, Cyclops);
 	}
 	else if (_format == VRSTEREOFORMAT_QUADBUFFERED) {
-		renderState->addData("StereoFormat", "QuadBuffered");
+		renderState->addData("/StereoFormat", "QuadBuffered");
 
 		_gfxToolkit->setDrawBuffer(VRGraphicsToolkit::VRDRAWBUFFER_BACKLEFT);
 		renderOneEye(renderState, renderHandler, Left);
@@ -39,20 +42,20 @@ void VRStereoNode::render(VRDataIndex *renderState, VRRenderHandler *renderHandl
 		renderOneEye(renderState, renderHandler, Right);
 	}
 	else if (_format == VRSTEREOFORMAT_SIDEBYSIDE) {
-		renderState->addData("StereoFormat", "SideBySide");
+		renderState->addData("/StereoFormat", "SideBySide");
 		
 		int x,y,w,h;
-		if (renderState->exists("ViewportX", "/")) {
-            x = renderState->getValue("ViewportX");
-            y = renderState->getValue("ViewportY");
-			w = renderState->getValue("ViewportWidth");
-			h = renderState->getValue("ViewportHeight");
+		if (renderState->exists("/ViewportX")) {
+            x = renderState->getValue("/ViewportX");
+            y = renderState->getValue("/ViewportY");
+			w = renderState->getValue("/ViewportWidth");
+			h = renderState->getValue("/ViewportHeight");
 		}
 		else {
             x = 0;
             y = 0;
-			w = renderState->getValue("WindowWidth");
-			h = renderState->getValue("WindowHeight");
+			w = renderState->getValue("/WindowWidth");
+			h = renderState->getValue("/WindowHeight");
 		}
 
 		_gfxToolkit->setSubWindow(VRRect(x,y,w/2,h));
@@ -62,7 +65,7 @@ void VRStereoNode::render(VRDataIndex *renderState, VRRenderHandler *renderHandl
 		renderOneEye(renderState, renderHandler, Right);
 	}
 	else if (_format == VRSTEREOFORMAT_COLUMNINTERLACED) {
-		renderState->addData("StereoFormat", "ColumnInterlaced");
+		renderState->addData("/StereoFormat", "ColumnInterlaced");
 
 		_gfxToolkit->disableDrawingOnEvenColumns();
 		renderOneEye(renderState, renderHandler, Left);
@@ -81,8 +84,9 @@ void VRStereoNode::updateLookAtMatrix(VRDataIndex *renderState, VREyePosition ey
 
 	VRMatrix4 lookAtMatrix;
 
-	if (renderState->exists("LookAtMatrix", "/")){
-		lookAtMatrix = renderState->getValue("LookAtMatrix");
+	if (renderState->exists("/LookAtMatrix"))
+  {
+		lookAtMatrix = renderState->getValue("/LookAtMatrix");
 	}
 
 	if (eye == Left)
@@ -98,7 +102,7 @@ void VRStereoNode::updateLookAtMatrix(VRDataIndex *renderState, VREyePosition ey
 		lookAtMatrix = head_frame.inverse();
 	}
 
-	renderState->addData("LookAtMatrix", lookAtMatrix);
+	renderState->addData("/LookAtMatrix", lookAtMatrix);
 }
 
 void VRStereoNode::renderOneEye(VRDataIndex *renderState, VRRenderHandler *renderHandler, VREyePosition eye)
@@ -108,16 +112,16 @@ void VRStereoNode::renderOneEye(VRDataIndex *renderState, VRRenderHandler *rende
 		if (_children.size() > 0) {
 			if (eye == Cyclops)
 			{
-				renderState->addData("Eye", "Cyclops");
+				renderState->addData("/Eye", "Cyclops");
 				_children[0]->render(renderState, renderHandler);		
 			}
 			else if (eye == Left){
-				renderState->addData("Eye", "Left");
+				renderState->addData("/Eye", "Left");
 				_children[0]->render(renderState, renderHandler);		
 			} 
 			else if (eye == Right)
 			{
-				renderState->addData("Eye", "Right");
+				renderState->addData("/Eye", "Right");
 				_children[1]->render(renderState, renderHandler);
 			}
 		}

--- a/src/display/VRTrackedLookAtNode.cpp
+++ b/src/display/VRTrackedLookAtNode.cpp
@@ -19,7 +19,7 @@ VRTrackedLookAtNode::render(VRDataIndex *renderState, VRRenderHandler *renderHan
 {
 	renderState->pushState();
 
-	renderState->addData("LookAtMatrix", _lookAtMatrix);
+	renderState->addData("/LookAtMatrix", _lookAtMatrix);
 
 	VRDisplayNode::render(renderState, renderHandler);
 

--- a/src/display/VRTrackedLookAtNode.cpp
+++ b/src/display/VRTrackedLookAtNode.cpp
@@ -7,6 +7,7 @@ namespace MinVR {
 	VRTrackedLookAtNode::VRTrackedLookAtNode(const std::string &name, const std::string &headTrackingEventName, VRMatrix4 initiallookAtMatrix) :
 		VRDisplayNode(name), _lookAtMatrix(initiallookAtMatrix), _trackingEvent(headTrackingEventName)
 {
+  _valuesAdded.push_back("/LookAtMatrix");
 }
 
 VRTrackedLookAtNode::~VRTrackedLookAtNode()

--- a/src/display/VRViewportNode.cpp
+++ b/src/display/VRViewportNode.cpp
@@ -13,6 +13,10 @@ namespace MinVR {
 
 VRViewportNode::VRViewportNode(const std::string &name, VRGraphicsToolkit *gfxToolkit, const VRRect& rect) :
 	VRDisplayNode(name), _rect(rect), _gfxToolkit(gfxToolkit)  {
+  _valuesAdded.push_back("/ViewportX");
+  _valuesAdded.push_back("/ViewportY");
+  _valuesAdded.push_back("/ViewportWidth");
+  _valuesAdded.push_back("/ViewportHeight");
 }
 
 VRViewportNode::~VRViewportNode() {

--- a/src/display/VRViewportNode.cpp
+++ b/src/display/VRViewportNode.cpp
@@ -22,10 +22,10 @@ void VRViewportNode::render(VRDataIndex *renderState, VRRenderHandler *renderHan
   renderState->pushState();
 
 	// Is this the kind of state information we expect to pass from one node to the next?
-	renderState->addData("ViewportX", (int)_rect.getX());
-	renderState->addData("ViewportY", (int)_rect.getY());
-	renderState->addData("ViewportWidth", (int)_rect.getWidth());
-	renderState->addData("ViewportHeight", (int)_rect.getHeight());
+	renderState->addData("/ViewportX", (int)_rect.getX());
+	renderState->addData("/ViewportY", (int)_rect.getY());
+	renderState->addData("/ViewportWidth", (int)_rect.getWidth());
+	renderState->addData("/ViewportHeight", (int)_rect.getHeight());
   
 	_gfxToolkit->setSubWindow(_rect);
 

--- a/src/display/VRWindowToolkit.h
+++ b/src/display/VRWindowToolkit.h
@@ -66,9 +66,9 @@ public:
  */
 class VRWindowToolkit {
 public:
-	~VRWindowToolkit() {}
+	virtual ~VRWindowToolkit() {}
 
-    virtual std::string getName() = 0;
+  virtual std::string getName() = 0;
 
 	virtual int createWindow(VRWindowSettings settings) = 0;
 

--- a/src/main/VRMain.cpp
+++ b/src/main/VRMain.cpp
@@ -593,7 +593,7 @@ VRMain::renderOnAllDisplays()
 	}
 
 	VRDataIndex renderState;
-	renderState.addData("InitRender", _frame == 0);
+	renderState.addData("/InitRender", _frame == 0);
 
 	if (!_displayGraphs.empty()) {
 		VRCompositeRenderHandler compositeHandler(_renderHandlers);

--- a/src/main/VRMain.cpp
+++ b/src/main/VRMain.cpp
@@ -306,8 +306,7 @@ void VRMain::initialize(const VRAppLauncher& launcher) {
 				&si,            // Pointer to STARTUPINFO structure
 				&pi )           // Pointer to PROCESS_INFORMATION structure
 		) {
-			std::cerr << "CreateProcess failed: " << GetLastError() << std::endl;
-			exit(1);
+			throw std::runtime_error("CreateProcess failed: " + GetLastError());
 		}
 
 		delete[] title;
@@ -544,8 +543,7 @@ void
 VRMain::synchronizeAndProcessEvents() 
 {
 	if (!_initialized) {
-		std::cerr << "VRMain not initialized." << std::endl;
-		return;
+		throw std::runtime_error("VRMain not initialized.");
 	}
 
 	VRDataQueue eventsFromDevices;
@@ -587,11 +585,8 @@ VRMain::synchronizeAndProcessEvents()
 void
 VRMain::renderOnAllDisplays() 
 {
-	if (!_initialized) {
-		std::cerr << "VRMain not initialized." << std::endl;
-		return;
-	}
-
+  if (!_initialized) throw std::runtime_error("VRMain not initialized.");
+  
 	VRDataIndex renderState;
 	renderState.addData("/InitRender", _frame == 0);
 
@@ -620,6 +615,29 @@ VRMain::renderOnAllDisplays()
 	}
 
 	_frame++;
+}
+
+std::list<std::string>
+VRMain::auditValuesFromAllDisplays() 
+{
+  std::list<std::string> out;
+
+  if (!_initialized) throw std::runtime_error("VRMain not initialized.");
+  
+	if (!_displayGraphs.empty()) {
+
+		for (std::vector<VRDisplayNode*>::iterator it = _displayGraphs.begin();
+         it != _displayGraphs.end(); ++it) {
+      std::map<std::string,std::string> subOut = (*it)->getValuesAdded();
+
+      for (std::map<std::string,std::string>::iterator jt = subOut.begin();
+           jt != subOut.end(); jt++) {
+        out.push_back(jt->first + " : " + jt->second);
+      }
+    }
+  }
+
+  return out;
 }
 
 

--- a/src/main/VRMain.cpp
+++ b/src/main/VRMain.cpp
@@ -157,7 +157,7 @@ void VRMain::initialize(int argc, char **argv, const std::string& configFile, st
 
 void VRMain::initialize(const VRAppLauncher& launcher) {
 	std::string data = launcher.getInitString();
-	std::cout << data << std::endl;
+  //	std::cout << "initializing launcher with: " << data << std::endl;
 
 	std::stringstream ss(data);
 

--- a/src/main/VRMain.h
+++ b/src/main/VRMain.h
@@ -116,7 +116,9 @@ public:
   void addPluginSearchPath(const std::string& path) {
 
   }
-   
+
+  std::list<std::string> auditValuesFromAllDisplays();
+  
 private:
 
   void initialize();


### PR DESCRIPTION
Should not, but did for a while. Some plugins and a bunch of the default display nodes used names without namespaces. Tried to fix them, undoubtedly missed some.

Changed the data index code so it will add the root name space if no namespace is given to addData() or the name does not start with a "/". But I did not make a corresponding change to exists() or getValue(), which will not find the values whose names do not have a namespace.