### PR TITLE
Added C++11 Cross Platform Frame Timer.

### DIFF
--- a/examples/MinGraphicsExample/desktop.xml
+++ b/examples/MinGraphicsExample/desktop.xml
@@ -2,6 +2,7 @@
   <PluginPath>../../../MinVR2/build/Release/plugins</PluginPath>
 	<GLFWPlugin pluginType="MinVR_GLFW"/>
 	<OpenGLPlugin pluginType="MinVR_OpenGL"/>
+	<CPP11Plugin pluginType="MinVR_CPP11"/>
 
 	  <RGBBits>8</RGBBits>
 	  <AlphaBits>8</AlphaBits>
@@ -29,6 +30,8 @@
   <EyeSeparation>0.203</EyeSeparation>
   <NearClip>0.001</NearClip>
   <FarClip>500.0</FarClip>
+  
+  <Timer inputdeviceType="VRCpp11Timer"/>
   
 	<VRSetups>
 		<Desktop hostType="VRStandAlone">

--- a/examples/ShaderExample/desktop.xml
+++ b/examples/ShaderExample/desktop.xml
@@ -2,6 +2,7 @@
   <PluginPath>../../../MinVR2/build/Release/plugins</PluginPath>
 	<GLFWPlugin pluginType="MinVR_GLFW"/>
 	<OpenGLPlugin pluginType="MinVR_OpenGL"/>
+	<CPP11Plugin pluginType="MinVR_CPP11"/>
 
 	  <RGBBits>8</RGBBits>
 	  <AlphaBits>8</AlphaBits>
@@ -29,6 +30,8 @@
   <EyeSeparation>0.203</EyeSeparation>
   <NearClip>0.001</NearClip>
   <FarClip>500.0</FarClip>
+  
+  <Timer inputdeviceType="VRCpp11Timer"/>
   
 	<VRSetups>
 		<Desktop hostType="VRStandAlone">

--- a/plugins/CMakeLists.txt
+++ b/plugins/CMakeLists.txt
@@ -26,6 +26,12 @@ if (MINVR_GLFW_PLUGIN OR BASE_PLUGINS)
 	add_subdirectory (GLFW)
 endif()
 
+#------------------C++ 11-----------------------------
+option(MINVR_CPP11_PLUGIN "If enabled, CPP11 plugin will be installed" OFF)
+if (MINVR_CPP11_PLUGIN OR BASE_PLUGINS)
+	add_subdirectory (CPP11)
+endif()
+
 #------------------VRPN-----------------------------
 option(MINVR_VRPN_PLUGIN "If enabled, VRPN plugin will be installed" OFF)
 if (MINVR_VRPN_PLUGIN)

--- a/plugins/CPP11/.gitignore
+++ b/plugins/CPP11/.gitignore
@@ -1,0 +1,58 @@
+# Emacs
+*~
+\#*\#
+/.emacs.desktop
+/.emacs.desktop.lock
+*.elc
+auto-save-list
+tramp
+.\#*
+
+# Build
+*_build
+build
+Makefile
+deps
+
+# VIM
+[._]*.s[a-w][a-z]
+[._]s[a-w][a-z]
+*.un~
+Session.vim
+.netrwhist
+*~
+
+# Compiled Object files
+*.slo
+*.lo
+*.o
+*.obj
+
+# Compiled Dynamic libraries
+*.so
+*.dylib
+*.dll
+
+# Compiled Static libraries
+*.lai
+*.la
+*.a
+*.lib
+
+# Executables
+*.exe
+*.out
+*.app
+
+# Other
+log.txt
+
+# Local files
+*-local.*
+Data
+
+# XCode
+*.DS_STORE
+
+# dependencies
+lib/glfw

--- a/plugins/CPP11/CMakeLists.txt
+++ b/plugins/CPP11/CMakeLists.txt
@@ -1,0 +1,117 @@
+project (MinVR_CPP11)
+
+set (SOURCEFILES 
+  src/VRCpp11Plugin.cpp
+  src/VRCpp11Timer.cpp
+)
+
+set (HEADERFILES
+  src/VRCpp11Timer.h
+)
+
+source_group("Header Files" FILES ${HEADERFILES})
+
+#------------------------------------------
+# MinVR Dependencies
+#------------------------------------------
+
+link_directories(${CMAKE_BINARY_DIR}/lib)
+
+#------------------------------------------
+# Include Directories
+#------------------------------------------
+
+# Include Directories
+include_directories (
+  src
+)
+
+#------------------------------------------
+# Specific preprocessor defines
+#------------------------------------------
+
+# Windows Section #
+if (MSVC)
+    add_definitions(-D_CRT_SECURE_NO_WARNINGS)
+    # Tell MSVC to use main instead of WinMain for Windows subsystem executables
+    set_target_properties(${WINDOWS_BINARIES} PROPERTIES LINK_FLAGS "/ENTRY:mainCRTStartup")
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11")
+endif()
+
+if (${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
+    set(CMAKE_CXX_FLAGS "-std=c++11 -stdlib=libc++")
+	set(CMAKE_XCODE_ATTRIBUTE_CLANG_CXX_LANGUAGE_STANDARD "c++11")
+	set(CMAKE_XCODE_ATTRIBUTE_CLANG_CXX_LIBRARY "libc++")
+	find_library(COCOA_LIB Cocoa)
+	find_library(IOKIT_LIB IOKit)
+	find_library(CORE_FOUNDATION_FRAMEWORK CoreFoundation)
+    	find_library(CORE_VIDEO_FRAMEWORK CoreVideo)
+	set(LIBS_ALL ${LIBS_ALL} ${COCOA_LIB} ${IOKIT_LIB} ${CORE_FOUNDATION_FRAMEWORK} ${CORE_VIDEO_FRAMEWORK})
+	message(STATUS "${CORE_VIDEO_FRAMEWORK}")
+endif()
+
+if (${CMAKE_SYSTEM_NAME} MATCHES "Linux")
+  if(CMAKE_CXX_COMPILER_VERSION VERSION_LESS "4.7")
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=gnu++0x")
+  else()
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11")
+  endif()
+  find_package(Threads)
+  find_package(X11)
+  set(LIBS_ALL ${LIBS_ALL} ${CMAKE_THREAD_LIBS_INIT} rt Xrandr Xxf86vm Xi m dl ${X11_LIBRARIES})
+endif()
+
+#------------------------------------------
+# Set output directories to lib, and bin
+#------------------------------------------
+
+make_directory(${CMAKE_BINARY_DIR}/lib)
+make_directory(${CMAKE_BINARY_DIR}/bin)
+set (CMAKE_ARCHIVE_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/plugins/${PROJECT_NAME}/lib)
+set (CMAKE_LIBRARY_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/plugins/${PROJECT_NAME}/lib)
+set (CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/plugins/${PROJECT_NAME}/bin)
+foreach (CONF ${CMAKE_CONFIGURATION_TYPES})
+	string (TOUPPER ${CONF} CONF)
+	set (CMAKE_RUNTIME_OUTPUT_DIRECTORY_${CONF} ${CMAKE_BINARY_DIR}/plugins/${PROJECT_NAME}/bin)
+	set (CMAKE_ARCHIVE_OUTPUT_DIRECTORY_${CONF} ${CMAKE_BINARY_DIR}/plugins/${PROJECT_NAME}/lib)
+	set (CMAKE_LIBRARY_OUTPUT_DIRECTORY_${CONF} ${CMAKE_BINARY_DIR}/plugins/${PROJECT_NAME}/lib)
+endforeach(CONF CMAKE_CONFIGURATION_TYPES)
+
+set(CMAKE_DEBUG_POSTFIX "d")
+set(CMAKE_RELEASE_POSTFIX "")
+set(CMAKE_RELWITHDEBINFO_POSTFIX "rd")
+set(CMAKE_MINSIZEREL_POSTFIX "s")
+
+#set the build postfix extension according to the current configuration
+if (CMAKE_BUILD_TYPE MATCHES "Release")
+	set(CMAKE_BUILD_POSTFIX "${CMAKE_RELEASE_POSTFIX}")
+elseif (CMAKE_BUILD_TYPE MATCHES "MinSizeRel")
+	set(CMAKE_BUILD_POSTFIX "${CMAKE_MINSIZEREL_POSTFIX}")
+elseif (CMAKE_BUILD_TYPE MATCHES "RelWithDebInfo")
+	set(CMAKE_BUILD_POSTFIX "${CMAKE_RELWITHDEBINFO_POSTFIX}")
+elseif (CMAKE_BUILD_TYPE MATCHES "Debug")
+	set(CMAKE_BUILD_POSTFIX "${CMAKE_DEBUG_POSTFIX}")
+else()
+	set(CMAKE_BUILD_POSTFIX "")
+endif()
+
+#------------------------------------------
+# Build Target
+#------------------------------------------
+
+SET(CMAKE_SKIP_BUILD_RPATH  FALSE)
+SET(CMAKE_BUILD_WITH_INSTALL_RPATH FALSE) 
+SET(CMAKE_INSTALL_RPATH "${VRPlugins_install_dir}/${PROJECT_NAME}/lib")
+SET(CMAKE_INSTALL_RPATH_USE_LINK_PATH TRUE)
+
+add_library ( ${PROJECT_NAME} SHARED ${HEADERFILES} ${SOURCEFILES} )
+target_link_libraries(${PROJECT_NAME} MinVR ${LIBS_ALL})
+
+#------------------------------------------
+# Install Target
+#------------------------------------------
+
+install( TARGETS ${PROJECT_NAME}
+         LIBRARY DESTINATION ${VRPlugins_install_dir}/${PROJECT_NAME}/lib
+         ARCHIVE DESTINATION ${VRPlugins_install_dir}/${PROJECT_NAME}/lib
+         RUNTIME DESTINATION ${VRPlugins_install_dir}/${PROJECT_NAME}/bin)

--- a/plugins/CPP11/src/VRCpp11Plugin.cpp
+++ b/plugins/CPP11/src/VRCpp11Plugin.cpp
@@ -1,0 +1,52 @@
+/*
+ * Copyright Regents of the University of Minnesota, 2015.  This software is released under the following license: http://opensource.org/licenses/GPL-2.0.
+ * Source code originally developed at the University of Minnesota Interactive Visualization Lab (http://ivlab.cs.umn.edu).
+ *
+ * Code author(s):
+ * 		Dan Orban (dtorban)
+ */
+
+#include <iostream>
+#include <plugin/VRPlugin.h>
+#include "main/VRFactory.h"
+
+#include <vector>
+#include <numeric>
+#include <chrono>
+#include "VRCpp11Timer.h"
+
+// special: include this only once in one .cpp file per plugin
+#include <plugin/VRPluginVersion.h>
+
+namespace MinVR {
+
+/** Threading Plugin for MinVR System.  Relies on c++11 threading or Boost for implementation.
+ */
+class VRThreadingPlugin : public MinVR::VRPlugin {
+public:
+	PLUGIN_API VRThreadingPlugin() {
+	}
+
+	PLUGIN_API virtual ~VRThreadingPlugin() {
+	}
+
+	PLUGIN_API void registerWithMinVR(VRMainInterface *vrMain)
+	{
+		vrMain->getFactory()->registerItemType<VRInputDevice, VRCpp11Timer>("VRCpp11Timer");
+	}
+
+	PLUGIN_API void unregisterWithMinVR(VRMainInterface *vrMain)
+	{
+	}
+
+};
+
+}
+
+extern "C"
+{
+	PLUGIN_API MinVR::VRPlugin* createPlugin() {
+		return new MinVR::VRThreadingPlugin();
+	}
+}
+

--- a/plugins/CPP11/src/VRCpp11Timer.cpp
+++ b/plugins/CPP11/src/VRCpp11Timer.cpp
@@ -1,0 +1,38 @@
+/*
+ * Copyright Regents of the University of Minnesota, 2017.  This software is released under the following license: http://opensource.org/licenses/
+ * Source code originally developed at the University of Minnesota Interactive Visualization Lab (http://ivlab.cs.umn.edu).
+ *
+ * Code author(s):
+ * 		Dan Orban (dtorban)
+ */
+
+#include "VRCpp11Timer.h"
+
+namespace MinVR {
+
+VRCpp11Timer::VRCpp11Timer() {
+	start = std::chrono::high_resolution_clock::now();
+}
+
+VRCpp11Timer::~VRCpp11Timer() {
+}
+
+VRInputDevice* VRCpp11Timer::create(VRMainInterface* vrMain,
+		VRDataIndex* config, const std::string& nameSpace) {
+	return new VRCpp11Timer();
+}
+
+double VRCpp11Timer::getTime() {
+	auto end = std::chrono::high_resolution_clock::now();
+	std::chrono::duration<double> diff = end-start;
+	return diff.count();
+}
+
+void VRCpp11Timer::appendNewInputEventsSinceLastCall(VRDataQueue* inputEvents) {
+	std::string event = "FrameStart";
+	std::string dataField = "/ElapsedSeconds";
+	dataIndex.addData(event + dataField, getTime());
+	inputEvents->push(dataIndex.serialize(event));
+}
+
+} /* namespace MinVR */

--- a/plugins/CPP11/src/VRCpp11Timer.h
+++ b/plugins/CPP11/src/VRCpp11Timer.h
@@ -1,0 +1,37 @@
+/*
+ * Copyright Regents of the University of Minnesota, 2017.  This software is released under the following license: http://opensource.org/licenses/
+ * Source code originally developed at the University of Minnesota Interactive Visualization Lab (http://ivlab.cs.umn.edu).
+ *
+ * Code author(s):
+ * 		Dan Orban (dtorban)
+ */
+
+#ifndef VRCPP11TIMER_H_
+#define VRCPP11TIMER_H_
+
+#include <chrono>
+#include "input/VRInputDevice.h"
+#include "main/VRMainInterface.h"
+#include "config/VRDataQueue.h"
+
+namespace MinVR {
+
+class VRCpp11Timer : public VRInputDevice {
+public:
+	VRCpp11Timer();
+	virtual ~VRCpp11Timer();
+
+	void appendNewInputEventsSinceLastCall(VRDataQueue *inputEvents);
+
+	static VRInputDevice* create(VRMainInterface *vrMain, VRDataIndex *config,const std::string &nameSpace);
+
+private:
+	double getTime();
+
+	std::chrono::time_point<std::chrono::high_resolution_clock> start;
+	VRDataIndex dataIndex;
+};
+
+} /* namespace MinVR */
+
+#endif /* VRCPP11TIMER_H_ */

--- a/plugins/GLFW/src/VRGLFWInputDevice.cpp
+++ b/plugins/GLFW/src/VRGLFWInputDevice.cpp
@@ -46,13 +46,6 @@ VRGLFWInputDevice::~VRGLFWInputDevice() {
 void VRGLFWInputDevice::appendNewInputEventsSinceLastCall(VRDataQueue* queue) {
     glfwPollEvents();
 
-    // TODO: This should be moved out of the GLFW plugin and made a standard
-    // event that MinVR creates at the start of each frame.
-    std::string event = "FrameStart";
-    std::string dataField = "/ElapsedSeconds";
-    _dataIndex.addData(event + dataField, glfwGetTime());
-    _events.push_back(_dataIndex.serialize(event));
-
     for (int f = 0; f < _events.size(); f++)
     {
     	queue->push(_events[f]);

--- a/plugins/GLFW/src/VRGLFWWindowToolkit.cpp
+++ b/plugins/GLFW/src/VRGLFWWindowToolkit.cpp
@@ -38,9 +38,6 @@ VRGLFWWindowToolkit::VRGLFWWindowToolkit(VRMainInterface *vrMain) : _vrMain(vrMa
 }
 
 VRGLFWWindowToolkit::~VRGLFWWindowToolkit() {
-	if (_inputDev != NULL) {
-		delete _inputDev;
-	}
     glfwTerminate();
 }
 

--- a/src/api/impl/VRApp.cpp
+++ b/src/api/impl/VRApp.cpp
@@ -37,7 +37,7 @@ public:
 	}
 
 	virtual ~VRAppInternal() {
-
+		delete _main;
 	}
 
 	void onVREvent(const VREvent &event) {


### PR DESCRIPTION
I added a plugin which creates a cross platform frame timer as an input device.  This fixes #90.  The idea is that per frame it will output the number of seconds since the program started.  It relies on the c++11 plugin for simplicity and ability to work across platform, but it is possible to create other types of timers.

Output will be the following event: /FrameStart/ElapsedSeconds

To get it to work add the following to your config file:

```xml
<MinVR>
        ...
	<CPP11Plugin pluginType="MinVR_CPP11"/>
        <Timer inputdeviceType="VRCpp11Timer"/>
         ...
</MinVR>
```
