### PR TITLE
Added GLFW Timer input device for cross platform frame timing data.

### DIFF
--- a/plugins/GLFW/CMakeLists.txt
+++ b/plugins/GLFW/CMakeLists.txt
@@ -3,6 +3,7 @@ project(MinVR_GLFW)
 set (SOURCEFILES 
   src/glew.c
   src/VRGLFWInputDevice.cpp
+  src/VRGLFWTimer.cpp
   src/VRGLFWPlugin.cpp
   src/VRGLFWWindowToolkit.cpp
 )

--- a/plugins/GLFW/src/VRGLFWInputDevice.cpp
+++ b/plugins/GLFW/src/VRGLFWInputDevice.cpp
@@ -48,10 +48,6 @@ void VRGLFWInputDevice::appendNewInputEventsSinceLastCall(VRDataQueue* queue) {
 
     // TODO: This should be moved out of the GLFW plugin and made a standard
     // event that MinVR creates at the start of each frame.
-    std::string event = "FrameStart";
-    std::string dataField = "/ElapsedSeconds";
-    _dataIndex.addData(event + dataField, (float)glfwGetTime());
-    _events.push_back(_dataIndex.serialize(event));
 
     for (int f = 0; f < _events.size(); f++)
     {

--- a/plugins/GLFW/src/VRGLFWPlugin.cpp
+++ b/plugins/GLFW/src/VRGLFWPlugin.cpp
@@ -13,6 +13,7 @@
 #include <plugin/VRPlugin.h>
 #include <display/VRWindowToolkit.h>
 #include "VRGLFWWindowToolkit.h"
+#include "VRGLFWTimer.h"
 
 
 // special: include this only once in one .cpp file per plugin
@@ -37,6 +38,7 @@ public:
 	{
       //std::cout << "Registering VRGLFWPlugin." << std::endl;
 		vrMain->getFactory()->registerItemType<VRWindowToolkit, VRGLFWWindowToolkit>("VRGLFWWindowToolkit");
+		vrMain->getFactory()->registerItemType<VRInputDevice, VRGLFWTimer>("VRGLFWTimer");
 	}
 
 	PLUGIN_API void unregisterWithMinVR(VRMainInterface *vrMain)

--- a/plugins/GLFW/src/VRGLFWTimer.cpp
+++ b/plugins/GLFW/src/VRGLFWTimer.cpp
@@ -1,0 +1,39 @@
+/*
+ * Copyright Regents of the University of Minnesota, 2017.  This software is released under the following license: http://opensource.org/licenses/
+ * Source code originally developed at the University of Minnesota Interactive Visualization Lab (http://ivlab.cs.umn.edu).
+ *
+ * Code author(s):
+ * 		Dan Orban (dtorban)
+ */
+
+#include <VRGLFWTimer.h>
+#include <GLFW/glfw3.h>
+
+namespace MinVR {
+
+VRGLFWTimer::VRGLFWTimer() {
+	// TODO Auto-generated constructor stub
+
+}
+
+VRGLFWTimer::~VRGLFWTimer() {
+	// TODO Auto-generated destructor stub
+
+}
+
+void VRGLFWTimer::appendNewInputEventsSinceLastCall(VRDataQueue *inputEvents) {
+	std::string event = "FrameStart";
+	std::string dataField = "/ElapsedSeconds";
+	float time = glfwGetTime();
+	dataIndex.addData(event + dataField, time);
+	inputEvents->push(dataIndex.serialize(event));
+}
+
+VRInputDevice* VRGLFWTimer::create(VRMainInterface *vrMain, VRDataIndex *config,const std::string &nameSpace) {
+	return new VRGLFWTimer();
+}
+
+} /* namespace MinVR */
+
+
+

--- a/plugins/GLFW/src/VRGLFWTimer.h
+++ b/plugins/GLFW/src/VRGLFWTimer.h
@@ -1,0 +1,33 @@
+/*
+ * Copyright Regents of the University of Minnesota, 2017.  This software is released under the following license: http://opensource.org/licenses/
+ * Source code originally developed at the University of Minnesota Interactive Visualization Lab (http://ivlab.cs.umn.edu).
+ *
+ * Code author(s):
+ * 		Dan Orban (dtorban)
+ */
+
+#ifndef VRGLFWTIMER_H_
+#define VRGLFWTIMER_H_
+
+#include <VRGLFWInputDevice.h>
+#include "main/VRMainInterface.h"
+#include "config/VRDataQueue.h"
+
+namespace MinVR {
+
+class VRGLFWTimer : public VRInputDevice {
+public:
+	VRGLFWTimer();
+	virtual ~VRGLFWTimer();
+
+	void appendNewInputEventsSinceLastCall(VRDataQueue *inputEvents);
+
+	static VRInputDevice* create(VRMainInterface *vrMain, VRDataIndex *config,const std::string &nameSpace);
+
+private:
+	VRDataIndex dataIndex;
+};
+
+} /* namespace MinVR */
+
+#endif /* VRGLFWTIMER_H_ */

--- a/plugins/GLFW/src/VRGLFWWindowToolkit.cpp
+++ b/plugins/GLFW/src/VRGLFWWindowToolkit.cpp
@@ -38,9 +38,6 @@ VRGLFWWindowToolkit::VRGLFWWindowToolkit(VRMainInterface *vrMain) : _vrMain(vrMa
 }
 
 VRGLFWWindowToolkit::~VRGLFWWindowToolkit() {
-	if (_inputDev != NULL) {
-		delete _inputDev;
-	}
     glfwTerminate();
 }
 

--- a/src/api/impl/VRApp.cpp
+++ b/src/api/impl/VRApp.cpp
@@ -37,7 +37,7 @@ public:
 	}
 
 	virtual ~VRAppInternal() {
-
+		delete _main;
 	}
 
 	void onVREvent(const VREvent &event) {

--- a/src/main/VRMain.cpp
+++ b/src/main/VRMain.cpp
@@ -650,9 +650,6 @@ VRMain::auditValuesFromAllDisplays()
 void 
 VRMain::shutdown()
 {
-	// TODO
-	_renderHandlers.clear();
-	_eventHandlers.clear();
     _shutdown = true;
 }
 

--- a/tests-interactive/opengl-fixedfuncpipeline/desktop.xml
+++ b/tests-interactive/opengl-fixedfuncpipeline/desktop.xml
@@ -33,6 +33,7 @@
 	<VRSetups>
 		<Desktop hostType="VRStandAlone">
 	      <GLFWToolkit windowtoolkitType="VRGLFWWindowToolkit"/>
+	      <GLFWTimer inputdeviceType="VRGLFWTimer"/>
 	      <OpenGLToolkit graphicstoolkitType="VROpenGLGraphicsToolkit"/>
 	      <RootNode displaynodeType="VRGraphicsWindowNode">
 				<Border>0</Border>

--- a/tests-interactive/opengl-fixedfuncpipeline/main.cpp
+++ b/tests-interactive/opengl-fixedfuncpipeline/main.cpp
@@ -28,17 +28,19 @@ public:
 
 	void onVREvent(const VREvent &event) {
         
-        event.print();
-		
-        // Get the time since application began
-		if (event.getName() == "FrameStart") {
-            time = event.getDataAsFloat("ElapsedSeconds");
-			return;
-		}
+		if (isRunning()) {
+			event.print();
 
-		// Quit if the escape button is pressed
-		if (event.getName() == "KbdEsc_Down") {
-			shutdown();
+			// Get the time since application began
+			if (event.getName() == "FrameStart") {
+				time = event.getDataAsFloat("ElapsedSeconds");
+				return;
+			}
+
+			// Quit if the escape button is pressed
+			if (event.getName() == "KbdEsc_Down") {
+				shutdown();
+			}
 		}
 	}
 
@@ -56,16 +58,18 @@ public:
 	}
 
 	void onVRRenderGraphics(const VRGraphicsState &renderState) {
-		// Get projection an view matrices
-		const float* projectionMatrix = renderState.getProjectionMatrix();
-		const float* viewMatrix = renderState.getViewMatrix();
+		if (isRunning()) {
+			// Get projection an view matrices
+			const float* projectionMatrix = renderState.getProjectionMatrix();
+			const float* viewMatrix = renderState.getViewMatrix();
 
-		// Show gradient of red color over four seconds then restart
-		float red = std::fmod(time/4.0,1.0);
-		glClearColor(red, 0, 0, 1);
-		glClear(GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT | GL_STENCIL_BUFFER_BIT);
+			// Show gradient of red color over four seconds then restart
+			float red = std::fmod(time/4.0,1.0);
+			glClearColor(red, 0, 0, 1);
+			glClear(GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT | GL_STENCIL_BUFFER_BIT);
 
-		// Draw calls here
+			// Draw calls here
+		}
 	}
 
 private:

--- a/tests-interactive/opengl-shaderpipeline/desktop.xml
+++ b/tests-interactive/opengl-shaderpipeline/desktop.xml
@@ -30,6 +30,7 @@
 	<VRSetups>
 		<Desktop hostType="VRStandAlone">
 	      <GLFWToolkit windowtoolkitType="VRGLFWWindowToolkit"/>
+	      <GLFWTimer inputdeviceType="VRGLFWTimer"/>
 	      <OpenGLToolkit graphicstoolkitType="VROpenGLGraphicsToolkit"/>
 	      <RootNode displaynodeType="VRGraphicsWindowNode">
 				<Border>0</Border>


### PR DESCRIPTION
This is necessary to fix part of #90.  We need a separate input device for timing since the VRGLFWInputDevice will be created per process.  We need to specify which process will handle the timing.  If we don't have this, multiple processes will all return conflicting time information.  For example, if we had a cave with 4 walls running on 4 different processes, each wall would return a separate frame elapsed time.  Therefore I added a VRGLFWTimer input device which handles it.  The good thing is that it relies on the Windowing library and not C++11.

**In other words, the test-interactive examples will fail (or look really shaky) in a cave without this fix.**

Here is an example of how to add it to the config file:

```xml
<MinVR>
	<GLFWPlugin pluginType="MinVR_GLFW"/>
        <GLFWTimer inputdeviceType="VRGLFWTimer"/>
         ...
	<VRSetups>
		<Desktop hostType="VRStandAlone">
	           ...
		</Desktop>
	</VRSetups>
</MinVR>
```

