### PR TITLE
Added cross platform time implementation and per frame time event.

### DIFF
--- a/plugins/GLFW/src/VRGLFWInputDevice.cpp
+++ b/plugins/GLFW/src/VRGLFWInputDevice.cpp
@@ -46,13 +46,6 @@ VRGLFWInputDevice::~VRGLFWInputDevice() {
 void VRGLFWInputDevice::appendNewInputEventsSinceLastCall(VRDataQueue* queue) {
     glfwPollEvents();
 
-    // TODO: This should be moved out of the GLFW plugin and made a standard
-    // event that MinVR creates at the start of each frame.
-    std::string event = "FrameStart";
-    std::string dataField = "/ElapsedSeconds";
-    _dataIndex.addData(event + dataField, (float)glfwGetTime());
-    _events.push_back(_dataIndex.serialize(event));
-
     for (int f = 0; f < _events.size(); f++)
     {
     	queue->push(_events[f]);

--- a/plugins/GLFW/src/VRGLFWWindowToolkit.cpp
+++ b/plugins/GLFW/src/VRGLFWWindowToolkit.cpp
@@ -38,9 +38,6 @@ VRGLFWWindowToolkit::VRGLFWWindowToolkit(VRMainInterface *vrMain) : _vrMain(vrMa
 }
 
 VRGLFWWindowToolkit::~VRGLFWWindowToolkit() {
-	if (_inputDev != NULL) {
-		delete _inputDev;
-	}
     glfwTerminate();
 }
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -124,6 +124,7 @@ set(vr_main_cpp
   ${vr_src_dir}/main/VRGraphicsHandler.cpp
   ${vr_src_dir}/main/VRGraphicsStateInternal.cpp
   ${vr_src_dir}/main/VRMain.cpp
+  ${vr_src_dir}/main/VRSystem.cpp
   ${vr_src_dir}/main/impl/VRDefaultAppLauncher.cpp
 )
 
@@ -151,6 +152,7 @@ set(vr_main_h_main
   ${vr_src_dir}/main/VRMain.h
   ${vr_src_dir}/main/VRMainInterface.h
   ${vr_src_dir}/main/VRRenderHandler.h
+  ${vr_src_dir}/main/VRSystem.h
 )
 
 set(vr_main_h_impl

--- a/src/api/impl/VRApp.cpp
+++ b/src/api/impl/VRApp.cpp
@@ -37,7 +37,7 @@ public:
 	}
 
 	virtual ~VRAppInternal() {
-
+		delete _main;
 	}
 
 	void onVREvent(const VREvent &event) {

--- a/src/main/VRMain.cpp
+++ b/src/main/VRMain.cpp
@@ -1,5 +1,7 @@
 #include <main/VRMain.h>
 
+#include <main/VRSystem.h>
+
 #include <stdio.h>
 #ifdef WIN32
 #include <windows.h>
@@ -160,6 +162,8 @@ void VRMain::initialize(int argc, char **argv, const std::string& configFile, st
 
 
 void VRMain::initialize(const VRAppLauncher& launcher) {
+	VRSystem::initialize();
+
 	std::string data = launcher.getInitString();
 
   //	std::cout << "initializing launcher with: " << data << std::endl;
@@ -550,6 +554,10 @@ VRMain::synchronizeAndProcessEvents()
 	}
 
 	VRDataQueue eventsFromDevices;
+    std::string event = "FrameStart";
+    std::string dataField = "/ElapsedSeconds";
+    _config->addData(event + dataField, (float)VRSystem::getTime());
+    eventsFromDevices.push(_config->serialize(event));
   
 	for (int f = 0; f < _inputDevices.size(); f++) {
 		_inputDevices[f]->appendNewInputEventsSinceLastCall(&eventsFromDevices);
@@ -650,9 +658,6 @@ VRMain::auditValuesFromAllDisplays()
 void 
 VRMain::shutdown()
 {
-	// TODO
-	_renderHandlers.clear();
-	_eventHandlers.clear();
     _shutdown = true;
 }
 

--- a/src/main/VRSystem.cpp
+++ b/src/main/VRSystem.cpp
@@ -1,0 +1,91 @@
+/*
+ * Copyright Regents of the University of Minnesota, 2017.  This software is released under the following license: http://opensource.org/licenses/
+ * Source code originally developed at the University of Minnesota Interactive Visualization Lab (http://ivlab.cs.umn.edu).
+ *
+ * Code author(s):
+ * 		Dan Orban (dtorban)
+ */
+
+#include <main/VRSystem.h>
+#include <iostream>
+
+namespace MinVR {
+
+double VRSystem::getTime(bool absolute) {
+	return instance().time(absolute);
+}
+
+VRSystem& VRSystem::instance() {
+	static VRSystem system;
+	return system;
+}
+
+VRSystem::VRSystem() {
+	initTime();
+}
+
+VRSystem::~VRSystem() {
+}
+
+// Adapted from G3D (https://sourceforge.net/p/g3d/code/HEAD/tree/G3D10/G3D.lib/source/System.cpp#l915)
+void VRSystem::initTime() {
+#if defined(WIN32)
+        if (QueryPerformanceFrequency(&counterFrequency)) {
+            QueryPerformanceCounter(&start);
+        }
+
+        struct _timeb t;
+        _ftime(&t);
+
+        initialTime = (double)t.time - t.timezone * 60 + (t.dstflag ? 60*60 : 0);
+
+#else
+        gettimeofday(&start, NULL);
+        // "sse" = "seconds since epoch".  The time
+        // function returns the seconds since the epoch
+        // GMT (perhaps more correctly called UTC).
+        time_t gmt = ::time(NULL);
+
+        // No call to free or delete is needed, but subsequent
+        // calls to asctime, ctime, mktime, etc. might overwrite
+        // local_time_vals.
+        tm* localTimeVals = localtime(&gmt);
+
+        time_t local = gmt;
+
+        if (localTimeVals) {
+            // tm_gmtoff is already corrected for daylight savings.
+            local = local + localTimeVals->tm_gmtoff;
+        }
+
+        initialTime = local;
+#endif
+}
+
+// Adapted from G3D (https://sourceforge.net/p/g3d/code/HEAD/tree/G3D10/G3D.lib/source/System.cpp#l915)
+double VRSystem::time(bool absolute) {
+	double timeOffset = 0.0;
+	if (absolute) {
+		timeOffset = initialTime;
+	}
+
+#if defined(WIN32)
+        LARGE_INTEGER now;
+        QueryPerformanceCounter(&now);
+
+        return ((RealTime)(now.QuadPart - start.QuadPart) /
+                counterFrequency.QuadPart) + timeOffset;
+#else
+        // Linux resolution defaults to 100Hz.
+        // There is no need to do a separate RDTSC call as gettimeofday
+        // actually uses RDTSC when on systems that support it, otherwise
+        // it uses the system clock.
+        struct timeval now;
+        gettimeofday(&now, NULL);
+
+        return (now.tv_sec  - start.tv_sec) +
+            (now.tv_usec - start.tv_usec) / 1e6 + timeOffset;
+#endif
+}
+
+} /* namespace MinVR2 */

--- a/src/main/VRSystem.h
+++ b/src/main/VRSystem.h
@@ -1,0 +1,56 @@
+/*
+ * Copyright Regents of the University of Minnesota, 2017.  This software is released under the following license: http://opensource.org/licenses/
+ * Source code originally developed at the University of Minnesota Interactive Visualization Lab (http://ivlab.cs.umn.edu).
+ *
+ * Code author(s):
+ * 		Dan Orban (dtorban)
+ */
+
+#ifndef VRSYSTEM_H_
+#define VRSYSTEM_H_
+
+#ifdef WIN32
+	#include <winsock2.h> // must be included before windows.h
+	#include <windows.h>
+	#include <ctime>
+#else
+	#include <sys/time.h>
+#endif
+
+namespace MinVR {
+
+/**
+ * VRSystem is a singleton class that holds cross platform system related implementations.  For example the
+ * getTime() method will give the number of seconds since initialization.  Calling initialize() will
+ * set all the variables necessary for calling the methods.  If initialize() is not called, the system
+ * will be set from the first time the instance is used.  For example, the initialize() method will start the
+ * timer.
+ */
+class VRSystem {
+public:
+	virtual ~VRSystem();
+
+	static void initialize() { instance(); }
+	static double getTime(bool absolute = false);
+
+protected:
+	static VRSystem& instance();
+
+private:
+	VRSystem();
+
+	void initTime();
+	double time(bool absolute);
+
+	double initialTime;
+#ifdef WIN32
+	LARGE_INTEGER timeStart;
+	LARGE_INTEGER counterFrequency;
+#else
+	struct timeval start;
+#endif
+};
+
+} /* namespace MinVR */
+
+#endif /* VRSYSTEM_H_ */

--- a/tests-interactive/opengl-fixedfuncpipeline/main.cpp
+++ b/tests-interactive/opengl-fixedfuncpipeline/main.cpp
@@ -28,17 +28,19 @@ public:
 
 	void onVREvent(const VREvent &event) {
         
-        event.print();
-		
-        // Get the time since application began
-		if (event.getName() == "FrameStart") {
-            time = event.getDataAsFloat("ElapsedSeconds");
-			return;
-		}
+		if (isRunning()) {
+			event.print();
 
-		// Quit if the escape button is pressed
-		if (event.getName() == "KbdEsc_Down") {
-			shutdown();
+			// Get the time since application began
+			if (event.getName() == "FrameStart") {
+				time = event.getDataAsFloat("ElapsedSeconds");
+				return;
+			}
+
+			// Quit if the escape button is pressed
+			if (event.getName() == "KbdEsc_Down") {
+				shutdown();
+			}
 		}
 	}
 
@@ -56,16 +58,18 @@ public:
 	}
 
 	void onVRRenderGraphics(const VRGraphicsState &renderState) {
-		// Get projection an view matrices
-		const float* projectionMatrix = renderState.getProjectionMatrix();
-		const float* viewMatrix = renderState.getViewMatrix();
+		if (isRunning()) {
+			// Get projection an view matrices
+			const float* projectionMatrix = renderState.getProjectionMatrix();
+			const float* viewMatrix = renderState.getViewMatrix();
 
-		// Show gradient of red color over four seconds then restart
-		float red = std::fmod(time/4.0,1.0);
-		glClearColor(red, 0, 0, 1);
-		glClear(GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT | GL_STENCIL_BUFFER_BIT);
+			// Show gradient of red color over four seconds then restart
+			float red = std::fmod(time/4.0,1.0);
+			glClearColor(red, 0, 0, 1);
+			glClear(GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT | GL_STENCIL_BUFFER_BIT);
 
-		// Draw calls here
+			// Draw calls here
+		}
 	}
 
 private:


### PR DESCRIPTION
To get the time anywhere in the MinVR system use the following method:

```c++
double time = VRSystem::getTime();
```

I also moved the ElapsedTime event to VRMain.