### PR TITLE
Beta plugin updates

### DIFF
--- a/plugins/OpenVR/cmake/FindOpenVR.cmake
+++ b/plugins/OpenVR/cmake/FindOpenVR.cmake
@@ -1,7 +1,7 @@
 find_path(OPENVR_INCLUDE_DIR openvr.h
           HINTS $ENV{OPENVR_INCLUDE_DIR} ${OPENVR_INCLUDE_DIR})
 
-find_library(OPENVR_LIBRARY NAMES openvr_api.lib openvr_api.so
+find_library(OPENVR_LIBRARY NAMES openvr_api.lib openvr_api.so openvr_api
              HINTS $ENV{OPENVR_LIB_DIR} ${OPENVR_LIB_DIR})
 
 set(OPENVR_LIBRARIES ${OPENVR_LIBRARY})

--- a/plugins/OpenVR/src/VROpenVRInputDevice.cpp
+++ b/plugins/OpenVR/src/VROpenVRInputDevice.cpp
@@ -45,6 +45,8 @@ void VROpenVRInputDevice::updatePoses(){
 	for( vr::TrackedDeviceIndex_t unDevice = 0; unDevice < devices.size(); unDevice++ )
 	{
 		std::string event_name = devices[unDevice];
+        _dataIndex.addData(event_name + "/Pose", poseToMatrix4( &m_rTrackedDevicePose[unDevice]));
+        
 		_dataIndex.addData(event_name + "/Pose", poseToMatrix4( &m_rTrackedDevicePose[unDevice]));
 		_events.push_back(_dataIndex.serialize(event_name));
 	}
@@ -79,7 +81,7 @@ void VROpenVRInputDevice::reportStates(){
 		vr::VRControllerState_t state;
 		vr::TrackedDevicePose_t pose;
 		if(m_pHMD->GetTrackedDeviceClass(unDevice) == vr::TrackedDeviceClass_Controller &&
-			m_pHMD->GetControllerStateWithPose( vr::VRCompositor()->GetTrackingSpace(), unDevice, &state ,&pose)){
+			m_pHMD->GetControllerStateWithPose( vr::VRCompositor()->GetTrackingSpace(), unDevice, &state, &pose)){
 			std::string event_name = devices[unDevice];
 			_dataIndex.addData(event_name + "/State/Pose", poseToMatrix4(&pose));
 

--- a/plugins/OpenVR/src/VROpenVRInputDevice.cpp
+++ b/plugins/OpenVR/src/VROpenVRInputDevice.cpp
@@ -259,7 +259,7 @@ VRMatrix4 VROpenVRInputDevice::poseToMatrix4(vr::TrackedDevicePose_t *pose)
 		return VRMatrix4();
 
 	
-	VRMatrix4 mat(
+	VRMatrix4 mat = VRMatrix4::fromRowMajorElements(
 		pose->mDeviceToAbsoluteTracking.m[0][0], pose->mDeviceToAbsoluteTracking.m[1][0], pose->mDeviceToAbsoluteTracking.m[2][0], 0.0, 
 		pose->mDeviceToAbsoluteTracking.m[0][1], pose->mDeviceToAbsoluteTracking.m[1][1], pose->mDeviceToAbsoluteTracking.m[2][1], 0.0,
 		pose->mDeviceToAbsoluteTracking.m[0][2], pose->mDeviceToAbsoluteTracking.m[1][2], pose->mDeviceToAbsoluteTracking.m[2][2], 0.0,

--- a/plugins/OpenVR/src/VROpenVRNode.cpp
+++ b/plugins/OpenVR/src/VROpenVRNode.cpp
@@ -251,7 +251,7 @@ VRMatrix4 VROpenVRNode::GetHMDMatrixProjectionEye( vr::Hmd_Eye nEye )
 
 	vr::HmdMatrix44_t mat = m_pHMD->GetProjectionMatrix( nEye, m_fNearClip, m_fFarClip, vr::API_OpenGL);
 	
-	VRMatrix4 out(
+    VRMatrix4 out = VRMatrix4::fromRowMajorElements(
 		mat.m[0][0], mat.m[1][0], mat.m[2][0], mat.m[3][0],
 		mat.m[0][1], mat.m[1][1], mat.m[2][1], mat.m[3][1], 
 		mat.m[0][2], mat.m[1][2], mat.m[2][2], mat.m[3][2], 
@@ -266,7 +266,7 @@ VRMatrix4 VROpenVRNode::GetHMDMatrixPoseEye( vr::Hmd_Eye nEye )
 		return VRMatrix4();
 
 	vr::HmdMatrix34_t matEyeRight = m_pHMD->GetEyeToHeadTransform( nEye );
-	VRMatrix4 matrixObj(
+    VRMatrix4 matrixObj = VRMatrix4::fromRowMajorElements(
 		matEyeRight.m[0][0], matEyeRight.m[1][0], matEyeRight.m[2][0], 0.0, 
 		matEyeRight.m[0][1], matEyeRight.m[1][1], matEyeRight.m[2][1], 0.0,
 		matEyeRight.m[0][2], matEyeRight.m[1][2], matEyeRight.m[2][2], 0.0,

--- a/plugins/TUIO/src/VRTUIODevice.cpp
+++ b/plugins/TUIO/src/VRTUIODevice.cpp
@@ -72,8 +72,8 @@ void VRTUIODevice::appendNewInputEventsSinceLastCall(VRDataQueue *inputEvents)
 		if (_cursorsDown.find(tcur->getCursorID()) == _cursorsDown.end()) {
 			std::string event = "Touch_Cursor_Down";
 			_dataIndex.addData(event + "/Id", tcur->getCursorID());
-			_dataIndex.addData(event + "/XPos", _xScale*tcur->getX());
-			_dataIndex.addData(event + "/YPos", _yScale*tcur->getY());
+			_dataIndex.addData(event + "/XPos", (float)_xScale*tcur->getX());
+			_dataIndex.addData(event + "/YPos", (float)_yScale*tcur->getY());
 			inputEvents->push(_dataIndex.serialize(event));
 			_cursorsDown.insert(tcur->getCursorID());
 		}
@@ -81,8 +81,8 @@ void VRTUIODevice::appendNewInputEventsSinceLastCall(VRDataQueue *inputEvents)
 		if (tcur->getMotionSpeed() > 0.0) {
 			std::string event = "Touch_Cursor_Move";
 			_dataIndex.addData(event + "/Id", tcur->getCursorID());
-			_dataIndex.addData(event + "/XPos", _xScale*tcur->getX());
-			_dataIndex.addData(event + "/YPos", _yScale*tcur->getY());
+			_dataIndex.addData(event + "/XPos", (float)_xScale*tcur->getX());
+			_dataIndex.addData(event + "/YPos", (float)_yScale*tcur->getY());
 			inputEvents->push(_dataIndex.serialize(event));
 		}
 

--- a/plugins/VRPN/src/VRVRPNAnalogDevice.cpp
+++ b/plugins/VRPN/src/VRVRPNAnalogDevice.cpp
@@ -99,7 +99,7 @@ std::string	VRVRPNAnalogDevice::getEventName(int channelNumber)
 	}
 }
 
-void VRVRPNAnalogDevice::sendEventIfChanged(int channelNumber, double data)
+void VRVRPNAnalogDevice::sendEventIfChanged(int channelNumber, float data)
 {
 	if (_channelValues[channelNumber] != data) {
 		//_pendingEvents.push_back(EventRef(new Event(_eventNames[channelNumber], data, nullptr, channelNumber, msg_time)));

--- a/plugins/VRPN/src/VRVRPNAnalogDevice.h
+++ b/plugins/VRPN/src/VRVRPNAnalogDevice.h
@@ -75,7 +75,7 @@ public:
 	PLUGIN_API virtual ~VRVRPNAnalogDevice();
 
 	PLUGIN_API void        appendNewInputEventsSinceLastCall(VRDataQueue *inputEvents);
-	PLUGIN_API void        sendEventIfChanged(int channelNumber, double data);
+	PLUGIN_API void        sendEventIfChanged(int channelNumber, float data);
 	PLUGIN_API std::string getEventName(int channelNumber);
 	PLUGIN_API size_t      numChannels() { return _eventNames.size(); }
 	PLUGIN_API static VRInputDevice* create(VRMainInterface *vrMain, VRDataIndex *config, const std::string &nameSpace);
@@ -83,7 +83,7 @@ public:
 private:
 	vrpn_Analog_Remote        *_vrpnDevice;
 	std::vector<std::string>   _eventNames;
-	std::vector<double>        _channelValues;
+	std::vector<float>        _channelValues;
 	VRDataQueue                _pendingEvents;
 };
 

--- a/plugins/VRPN/src/VRVRPNTrackerDevice.cpp
+++ b/plugins/VRPN/src/VRVRPNTrackerDevice.cpp
@@ -70,12 +70,14 @@ void VRPN_CALLBACK trackerHandler(void *thisPtr, const vrpn_TRACKERCB info)
 {
     double rotraw[16];
     q_to_ogl_matrix(rotraw, info.quat);
-    VRMatrix4 vrpnEvent(rotraw);
-  
-   // VRMatrix4 vrpnEvent;
-    vrpnEvent[3][0] = info.pos[0];
-    vrpnEvent[3][1] = info.pos[1];
-    vrpnEvent[3][2] = info.pos[2];
+    float rotrawf[16];
+    for (int i=0; i<16; i++) {
+        rotrawf[i] = (float)rotraw[i];
+    }
+    VRMatrix4 vrpnEvent(rotrawf);
+    vrpnEvent(0,3) = info.pos[0];
+    vrpnEvent(1,3) = info.pos[1];
+    vrpnEvent(2,3) = info.pos[2];
   
 	VRVRPNTrackerDevice* device = ((VRVRPNTrackerDevice*)thisPtr);
 	device->processEvent(vrpnEvent, info.sensor);
@@ -159,17 +161,17 @@ void VRVRPNTrackerDevice::processEvent(const VRMatrix4 &vrpnEvent, int sensorNum
 		// Coordinates to Right-Handed Coordinates" by David Eberly,
 		// available online:
 		// http://www.geometrictools.com/Documentation/LeftHandedToRightHanded.pdf
-		trackerToDevice[3][2] = -trackerToDevice[3][2];
+		trackerToDevice(2,3) = -trackerToDevice(2,3);
 
-		trackerToDevice[2][0] = -trackerToDevice[2][0];
-		trackerToDevice[2][1] = -trackerToDevice[2][1];
-		trackerToDevice[0][2] = -trackerToDevice[0][2];
-		trackerToDevice[1][2] = -trackerToDevice[1][2];
+		trackerToDevice(0,2) = -trackerToDevice(0,2);
+		trackerToDevice(1,2) = -trackerToDevice(1,2);
+        trackerToDevice(2,0) = -trackerToDevice(2,0);
+		trackerToDevice(2,1) = -trackerToDevice(2,1);
 	}
 
-	trackerToDevice[3][0] *= _trackerUnitsToRoomUnitsScale;
-	trackerToDevice[3][1] *= _trackerUnitsToRoomUnitsScale;
-	trackerToDevice[3][2] *= _trackerUnitsToRoomUnitsScale;
+	trackerToDevice(0,3) *= _trackerUnitsToRoomUnitsScale;
+	trackerToDevice(1,3) *= _trackerUnitsToRoomUnitsScale;
+	trackerToDevice(2,3) *= _trackerUnitsToRoomUnitsScale;
 
 	VRMatrix4 eventRoom = _finalOffset[sensorNum] * _deviceToRoom * trackerToDevice * _propToTracker[sensorNum];
 

--- a/plugins/VRPN/src/VRVRPNTrackerDevice.h
+++ b/plugins/VRPN/src/VRVRPNTrackerDevice.h
@@ -128,7 +128,6 @@ public:
 	PLUGIN_API static VRInputDevice* create(VRMainInterface *vrMain, VRDataIndex *config, const std::string &nameSpace);
 
 private:
-	vrpn_Connection          *_vrpnConnection;
 	vrpn_Tracker_Remote      *_vrpnDevice;
 	std::vector<std::string>  _eventNames;
 	double                    _trackerUnitsToRoomUnitsScale;

--- a/src/config/VRCoreTypes.h
+++ b/src/config/VRCoreTypes.h
@@ -54,43 +54,43 @@ typedef enum
 // Convert to a VRInt
 class VRIntConvertible {
 public:
-  virtual VRInt toVRInt() = 0;
+  virtual VRInt toVRInt() const = 0;
 };
 
 // Convert to a VRFloat
 class VRFloatConvertible {
 public:
-  virtual VRFloat toVRFloat() = 0;
+  virtual VRFloat toVRFloat() const = 0;
 };
 
 // Convert to a VRString
 class VRStringConvertible {
 public:
-  virtual VRString toVRString() = 0;
+  virtual VRString toVRString() const = 0;
 };
 
 // Convert to a VRIntArray
 class VRIntArrayConvertible {
 public:
-  virtual VRIntArray toVRIntArray() = 0;
+  virtual VRIntArray toVRIntArray() const = 0;
 };
 
 // Convert to a VRFloatArray
 class VRFloatArrayConvertible {
 public:
-  virtual VRFloatArray toVRFloatArray() = 0;
+  virtual VRFloatArray toVRFloatArray() const = 0;
 };
 
 // Convert to a VRStringArray
 class VRStringArrayConvertible {
 public:
-  virtual VRStringArray toVRStringArray() = 0;
+  virtual VRStringArray toVRStringArray() const = 0;
 };
 
 // Convert to a VRContainer
 class VRContainerConvertible {
 public:
-  virtual VRContainer toVRContainer() = 0;
+  virtual VRContainer toVRContainer() const = 0;
 };
 
 } // end namespace MinVR

--- a/src/config/VRDataIndex.h
+++ b/src/config/VRDataIndex.h
@@ -515,27 +515,27 @@ public:
   // VRDatum types.  If those types include a constructor from the basic
   // type, then this is all they need to be stored into an index and
   // retrieved.
-  std::string addData(const std::string &name, VRIntConvertible &object) {
+  std::string addData(const std::string &name, const VRIntConvertible &object) {
     return addData(name, object.toVRInt());
   }
 
-  std::string addData(const std::string &name, VRFloatConvertible &object) {
+  std::string addData(const std::string &name, const VRFloatConvertible &object) {
     return addData(name, object.toVRFloat());
   }
 
-  std::string addData(const std::string &name, VRStringConvertible &object) {
+  std::string addData(const std::string &name, const VRStringConvertible &object) {
     return addData(name, object.toVRString());
   }
 
-  std::string addData(const std::string &name, VRIntArrayConvertible &object) {
+  std::string addData(const std::string &name, const VRIntArrayConvertible &object) {
     return addData(name, object.toVRIntArray());
   }
   
-  std::string addData(const std::string &name, VRFloatArrayConvertible &object) {
+  std::string addData(const std::string &name, const VRFloatArrayConvertible &object) {
     return addData(name, object.toVRFloatArray());
   }
   
-  std::string addData(const std::string &name, VRStringArrayConvertible &object) {
+  std::string addData(const std::string &name, const VRStringArrayConvertible &object) {
     return addData(name, object.toVRStringArray());
   }
   

--- a/src/math/VRMath.cpp
+++ b/src/math/VRMath.cpp
@@ -63,7 +63,7 @@ float& VRPoint3::operator[](const int i) {
   else return z;
 }
 
-VRFloatArray VRPoint3::toVRFloatArray() {
+VRFloatArray VRPoint3::toVRFloatArray() const {
   VRFloatArray a;
   a.push_back(x);
   a.push_back(y);
@@ -156,7 +156,7 @@ VRVector3 VRVector3::normalize() {
   return VRVector3(xx, yy, zz);
 }
 
-VRFloatArray VRVector3::toVRFloatArray() {
+VRFloatArray VRVector3::toVRFloatArray() const {
   VRFloatArray a;
   a.push_back(x);
   a.push_back(y);
@@ -426,7 +426,7 @@ VRVector3 VRMatrix4::getColumn(int c) const {
 }
 
 
-VRFloatArray VRMatrix4::toVRFloatArray() {
+VRFloatArray VRMatrix4::toVRFloatArray() const {
   VRFloatArray a;
   a.push_back(m[0]);
   a.push_back(m[1]);

--- a/src/math/VRMath.h
+++ b/src/math/VRMath.h
@@ -178,7 +178,7 @@ public:
   float* getArray() { return m; }
     
   /// Access an individual element of the array using the syntax:
-  /// VRMatrix4 mat; dobule row1col2 = mat(1,2);
+  /// VRMatrix4 mat; float row1col2 = mat(1,2);
   float operator()(const int row, const int col) const;
 
   /// Access an individual element of the array using the syntax:

--- a/src/math/VRMath.h
+++ b/src/math/VRMath.h
@@ -62,7 +62,7 @@ public:
   float& operator[](const int i);
   
   /// Converts the point to a VRFloatArray for data in a VRDataIndex
-  VRFloatArray toVRFloatArray();
+  VRFloatArray toVRFloatArray() const;
 
 public:
   float x,y,z; 
@@ -129,7 +129,7 @@ public:
   VRVector3 normalize();
   
   /// Converts the point to a VRFloatArray for data in a VRDataIndex
-  VRFloatArray toVRFloatArray();
+  VRFloatArray toVRFloatArray() const;
 
 public:
   float x,y,z; 
@@ -252,7 +252,7 @@ public:
   
     
   /// Converts the point to a VRFloatArray for storage in a VRDataIndex
-  VRFloatArray toVRFloatArray();
+  VRFloatArray toVRFloatArray() const;
     
     
 private:


### PR DESCRIPTION
@BenKnorlein -- in response to your request over email.  This should bring the VRPN and TUIO plugins up to date with the beta branch.  The base plugins were all already up to date, and no changes are needed in the Threading plugin.  

OpenVR:  I cannot get the openvr plugin to compile on my system.  It complains that it cannot find a dependency on glew.  I tried to build and install glew myself from github and from a zip file, and neither would work on my OSX system.  I am giving up for now, but I did change one line that I think would be a problem inside the openvr plugin.  So, this is untested, but it might be the only change you need.  Could you help to test this?

FreeGLUT:  Similar story, no freeglut installed on my machine, so I did not test this.  However, I did a grep for "double" and "Matrix4" in the freeglut source, and it doesn't seem to use either, so I think it was likely not affected by the change from doubles to floats and any adjustments to the VRMatrix4 class.