### PR TITLE
edited FreeGLUT cmake find to work better on Mac OSX

### DIFF
--- a/plugins/FREEGLUT/cmake/FindFreeGLUT.cmake
+++ b/plugins/FREEGLUT/cmake/FindFreeGLUT.cmake
@@ -15,35 +15,40 @@
 #  FREEGLUT_LIBRARIES    - List of libraries when using FreeGLUT.
 #  FREEGLUT_FOUND        - True if FreeGLUT found.
 
+# Hack: On OSX, this makes sure *not* to use the Glut files that come
+# with the system.  These appear not to be the same freeglut that we
+# are counting on.
+set(CMAKE_FIND_FRAMEWORK "NEVER")
+
 # Look for the header file.
 FIND_PATH(FREEGLUT_INCLUDE_DIR 
-          NAMES GL/freeglut.h
-	  HINTS 
-	  ENV CPATH # For OSCAR modules at Brown/CCV
-	  )
+  NAMES GL/freeglut.h
+	HINTS 
+	ENV CPATH # For OSCAR modules at Brown/CCV
+  /usr/local/Cellar/freeglut/2.8.1/include # This is how it comes with Brew.
+  /usr/local/Cellar/freeglut/3.0.0/include # This another way it comes with Brew.
+	)
 
 # Look for the library.
 FIND_LIBRARY(FREEGLUT_LIBRARY 
-             NAMES glut
-	     HINTS
-	     ENV LD_LIBRARY_PATH # For OSCAR modules at Brown/CCV
-	     )
+  NAMES glut
+	HINTS
+	ENV LD_LIBRARY_PATH # For OSCAR modules at Brown/CCV
+  /usr/local/Cellar/freeglut/2.8.1/lib/libglut.3.dylib # Brew version.
+  /usr/local/Cellar/freeglut/3.0.0/lib/libglut.3.dylib # Another Brew version.
+	)
 
-# Handle the QUIETLY and REQUIRED arguments and set FREEGLUT_FOUND to TRUE if all listed variables are TRUE.
+# Undo the above hack.
+set(CMAKE_FIND_FRAMEWORK)
+
+# Handle the QUIETLY and REQUIRED arguments and set FREEGLUT_FOUND to
+# TRUE if all listed variables are TRUE.
 INCLUDE(FindPackageHandleStandardArgs)
 FIND_PACKAGE_HANDLE_STANDARD_ARGS(
   FREEGLUT 
   DEFAULT_MSG 
   FREEGLUT_LIBRARY 
   FREEGLUT_INCLUDE_DIR)
-
-# If you're using a Brew version of FreeGLUT, these might work.  Too specific
-# to add into a hint for FIND_LIBRARY or FIND_PATH.
-#set(FREEGLUT_INCLUDE_DIR /usr/local/Cellar/freeglut/2.8.1/include)
-#set(FREEGLUT_LIBRARY /usr/local/Cellar/freeglut/2.8.1/lib/libglut.3.dylib)
-
-message("FreeGLUT library: " ${FREEGLUT_LIBRARY})
-message("FreeGLUT include: " ${FREEGLUT_INCLUDE_DIR})
 
 # Copy the results to the output variables.
 IF(FREEGLUT_FOUND)
@@ -52,6 +57,16 @@ IF(FREEGLUT_FOUND)
 ELSE(FREEGLUT_FOUND)
 	SET(FREEGLUT_LIBRARIES)
 	SET(FREEGLUT_INCLUDE_DIRS)
+  message("You can specify the FreeGLUT paths with -DFREEGLUT_INCLUDE_DIR=/path")
+  message("and -DFREEGLUT_LIBRARY=/path/to/libglut")
+  message("Or set the variables in MinVR/plugins/FREEGLUT/FindFreeGLUT.cmake.")
 ENDIF(FREEGLUT_FOUND)
+
+## Uncomment and edit these lines for your machine if there seems to be no hope.
+## set(FREEGLUT_LIBRARIES /path/to/libglut)
+## set(FREEGLUT_INCLUDE_DIRS /path/to/freeglut/include/files)
+
+message("-- FreeGLUT libraries: " ${FREEGLUT_LIBRARIES})
+message("-- FreeGLUT includes:  " ${FREEGLUT_INCLUDE_DIRS})
 
 MARK_AS_ADVANCED(FREEGLUT_INCLUDE_DIRS FREEGLUT_LIBRARIES)


### PR DESCRIPTION
This is just a minor modification to the FindFreeGLUT.cmake file to help it work on Mac OS X. There are two changes: one is to add the default file paths for the Homebrew installation version of freeglut, and the other avoids using the GLUT framework that comes with the system, which appears to make the FreeGLUT plugin compile fail.

Also added some extra messages and advice about how to fix things if FreeGLUT is not found.