### PR TITLE
Temporary fix: Client will try to connect to server until it has a

### DIFF
--- a/src/net/VRNetClient.cpp
+++ b/src/net/VRNetClient.cpp
@@ -40,21 +40,24 @@ VRNetClient::VRNetClient(const std::string &serverIP, const std::string &serverP
     exit(1);
   }
 
-  // loop through all the results and connect to the first we can
-  for (p = servinfo; p != NULL; p = p->ai_next) {
-    if ((sockfd = socket(p->ai_family, p->ai_socktype, p->ai_protocol)) == INVALID_SOCKET) {
-	  std::cerr << "socket() failed with error: " << WSAGetLastError() << std::endl;
-      continue;
-    }
+  //This is a temporary fix to ensure the client can connect and that the connection is not refused
+  while(p == NULL){
+    // loop through all the results and connect to the first we can
+    for (p = servinfo; p != NULL; p = p->ai_next) {
+      if ((sockfd = socket(p->ai_family, p->ai_socktype, p->ai_protocol)) == INVALID_SOCKET) {
+	    std::cerr << "socket() failed with error: " << WSAGetLastError() << std::endl;
+        continue;
+      }
     
-    if (connect(sockfd, p->ai_addr, (int)p->ai_addrlen) == SOCKET_ERROR) {
-      closesocket(sockfd);
-      sockfd = INVALID_SOCKET;
-	  std::cerr << "connect() to server socket failed" << std::endl;
-      continue;
-    }
+      if (connect(sockfd, p->ai_addr, (int)p->ai_addrlen) == SOCKET_ERROR) {
+        closesocket(sockfd);
+        sockfd = INVALID_SOCKET;
+	    std::cerr << "connect() to server socket failed" << std::endl;
+        continue;
+      }
     
-    break;
+      break;
+    }
   }
 
   if (p == NULL) {
@@ -94,22 +97,24 @@ VRNetClient::VRNetClient(const std::string &serverIP, const std::string &serverP
     exit(1);
   }
   
-  // loop through all the results and connect to the first we can
-  for (p = servinfo; p != NULL; p = p->ai_next) {
-    if ((sockfd = socket(p->ai_family, p->ai_socktype, p->ai_protocol)) == -1) {
-      perror("client: socket");
-      continue;
-    }
+  //This is a temporary fix to ensure the client can connect and that the connection is not refused
+  while(p == NULL){
+    // loop through all the results and connect to the first we can
+    for (p = servinfo; p != NULL; p = p->ai_next) {
+      if ((sockfd = socket(p->ai_family, p->ai_socktype, p->ai_protocol)) == -1) {
+        perror("client: socket");
+        continue;
+      }
     
-    if (connect(sockfd, p->ai_addr, p->ai_addrlen) == -1) {
-      close(sockfd);
-      perror("client: connect");
-      continue;
-    }
+      if (connect(sockfd, p->ai_addr, p->ai_addrlen) == -1) {
+        close(sockfd);
+        perror("client: connect");
+        continue;
+      }
     
-    break;
+      break;
+    }
   }
-
   if (p == NULL) {
     fprintf(stderr, "client: failed to connect\n");
     //return 2;


### PR DESCRIPTION
The clients sometimes did not manage to connect when the server was either not ready or busy with another connection. In that case the connection is refused and MinVR will never start. This is a temporary fix, but we should probably look into it in more detail, e.g. what happens if the server is started last.