### PR TITLE
added new constructor for data index, can serialize whole index

### DIFF
--- a/src/config/VRDataIndex.h
+++ b/src/config/VRDataIndex.h
@@ -206,6 +206,9 @@ private:
   //typedef std::map<std::string, std::vector<VRDatumPtr> > VRDataMap;
   VRDataMap mindex;
 
+  // This is the name of the data index itself.
+  std::string name; 
+  
   // If this is 1, new values will overwrite old ones.  For -1, new
   // values will just bounce off.  And zero will cause an exception if
   // an overwrite is attempted.  Except containers, who are always
@@ -344,13 +347,18 @@ private:
 
 public:
   VRDataIndex();
+  VRDataIndex(const std::string serializedData);
 
   // Some constants that may be useful to users of this API.
   static std::string rootNameSpace;
   
   void setOverwrite(const int inVal) { overwrite = inVal; }
 
-  // Returns the fully qualified name of the value.
+  // Returns the name of the whole data index.
+  std::string getName() { return name; };
+  void setName(const std::string inName) { name = inName; };
+  
+  // Returns the fully qualified name of the specified value.
   std::string getName(const std::string valName,
                       const std::string nameSpace);
 
@@ -412,6 +420,7 @@ public:
   }
 
   // This is the name, type, value, expressed as an XML fragment.
+  std::string serialize();
   std::string serialize(const std::string valName);
   std::string serialize(const std::string valName,
                         const std::string nameSpace);

--- a/tests-batch/config/CMakeLists.txt
+++ b/tests-batch/config/CMakeLists.txt
@@ -8,7 +8,7 @@ set (dataindextests datum index queue)
 # The numbers here correspond to 'case' statements in the respective
 # test program.  See, e.g., datumtest.cpp
 set (datum_parts 1 2 3 4 5 6 7 8 9 10)
-set (index_parts 1 2 3 4 5 6 7 8 9 10)
+set (index_parts 1 2 3 4 5 6 7 8 9 10 11)
 set (queue_parts 1 2 3)
 
 # For tests where a list of parts has not been defined we add a default of 1:

--- a/tests-batch/config/indextest.cpp
+++ b/tests-batch/config/indextest.cpp
@@ -1,6 +1,7 @@
 #include "config/VRDataIndex.h"
 
 int testIndexSerialize();
+int testIndexSerializeEntire();
 int testIndexSerializeIntArray();
 int testIndexSerializeIntArraySep();
 int testIndexPrintFloatArray();
@@ -12,7 +13,7 @@ int testLinkNode();
 int testLinkContent();
 
 // Make this a large number to get decent timing data.
-#define LOOP for (int loopctr = 0; loopctr < 100; loopctr++)
+#define LOOP for (int loopctr = 0; loopctr < 10; loopctr++)
 
 int indextest(int argc, char* argv[]) {
   
@@ -68,6 +69,10 @@ int indextest(int argc, char* argv[]) {
 
   case 10:
     output = testLinkContent();
+    break;
+
+  case 11:
+    output = testIndexSerializeEntire();
     break;
     
   default:
@@ -459,6 +464,39 @@ int testIndexSerialize() {
   return out;
   
 }
+
+int testIndexSerializeEntire() {
+
+  std::string testString = "<MVR type=\"container\"><Server type=\"container\"><Port type=\"string\">3490</Port><Host type=\"string\">localhost</Host><NumClients type=\"int\">1</NumClients></Server><VRPlugins type=\"container\"><MinVRDefaultPlugins type=\"container\"><Names type=\"stringarray\" separator=\"@\">MinVR_GLFW@MinVR_OpenGL@MinVR_Threading</Names><Data type=\"floatarray\">1.200000,2.300000,3.400000,4.500000,5.600000</Data></MinVRDefaultPlugins></VRPlugins><VRDisplayDevices type=\"container\"><ThreadedDisplay type=\"container\"><displayType type=\"string\">thread_group</displayType><Display1 type=\"container\"><allowThreading type=\"int\">1</allowThreading><displayType type=\"string\" val=\"heavy\">glfw_display</displayType><xOffset type=\"int\">600</xOffset><yOffset type=\"int\">0</yOffset><width type=\"int\">200</width><height type=\"int\">200</height></Display1><Display2 type=\"container\"><displayType type=\"string\">glfw_display</displayType><allowThreading type=\"int\">1</allowThreading><xOffset type=\"int\">600</xOffset><yOffset type=\"int\">250</yOffset><width type=\"int\">200</width><height type=\"int\">200</height><stereoFormatter type=\"container\"><displayType type=\"string\">sideBySideStereo</displayType></stereoFormatter></Display2><Display3 type=\"container\"><displayType type=\"string\">glfw_display</displayType><allowThreading type=\"int\">1</allowThreading><xOffset type=\"int\">600</xOffset><yOffset type=\"int\">450</yOffset><width type=\"int\">200</width><height type=\"int\">200</height><stereoFormatter type=\"container\"><displayType type=\"string\">sideBySideStereo</displayType></stereoFormatter></Display3></ThreadedDisplay><MainDisplay type=\"container\"><displayType type=\"string\">glfw_display</displayType><xOffset type=\"int\">800</xOffset><yOffset type=\"int\">0</yOffset><width type=\"int\">300</width><height type=\"int\">600</height></MainDisplay><OtherDisplay type=\"container\"><displayType type=\"string\">glfw_display</displayType><xOffset type=\"int\">0</xOffset><yOffset type=\"int\">0</yOffset><width type=\"int\">600</width><height type=\"int\">600</height><stereoFormatter type=\"container\"><displayType type=\"string\">sideBySideStereo</displayType><topViewport type=\"container\"><displayType type=\"string\">viewport</displayType><xOffset type=\"int\">0</xOffset><yOffset type=\"int\">300</yOffset><width type=\"int\">600</width><height type=\"int\">300</height></topViewport><bottomViewport type=\"container\"><displayType type=\"string\">viewport</displayType><xOffset type=\"int\">0</xOffset><yOffset type=\"int\">0</yOffset><width type=\"int\">600</width><height type=\"int\">300</height></bottomViewport></stereoFormatter></OtherDisplay><radius type=\"float\">20.000000</radius><Display1 type=\"container\"><radius type=\"float\">7.000000</radius><xOffset type=\"int\">0</xOffset><yOffset type=\"int\">300</yOffset></Display1><Display2 type=\"container\"><xOffset type=\"int\">0</xOffset><yOffset type=\"int\">300</yOffset></Display2></VRDisplayDevices></MVR>";
+
+  int out = 0;
+
+  LOOP {
+  
+    MinVR::VRDataIndex* n = new MinVR::VRDataIndex(testString);
+
+    std::string output = n->serialize();
+
+
+    // This uses the constructor, so the "MVR" gets absorbed as the
+    // name of the index, not the root name in the index.
+    std::string test1 = n->getValue("/VRDisplayDevices/ThreadedDisplay/Display1/displayType");
+
+    std::string test2 = n->getDatum("/VRDisplayDevices/ThreadedDisplay/Display1/displayType")->getAttributeValue("val");
+
+    out += test1.compare("glfw_display");
+    out += test2.compare("heavy");
+    out += 2871 - output.size();
+    out += n->getName().compare("MVR");
+    
+    delete n;
+  }
+
+  return out;
+  
+}
+
+
 
 int testIndexPrintFloatArray() {
 

--- a/tests-interactive/config-viewer/exercz.cpp
+++ b/tests-interactive/config-viewer/exercz.cpp
@@ -100,6 +100,31 @@ int main(int argc, char** argv) {
 
       index->processXMLFile(elems[1], nameSpace);
 
+    /////// command: new (open file, replace index)
+    } else if (elems[0].compare("new") == 0) {
+
+      if (elems.size() > 1) {
+
+        ifstream file(elems[1].c_str());
+
+        if (file.is_open()) {
+          std::stringstream buffer;
+          buffer << file.rdbuf();
+          index = new MinVR::VRDataIndex(buffer.str());
+
+        } else {
+
+          std::cout << "Couldn't open file: " << elems[1] << std::endl;
+        }
+      } else {
+
+        std::cout << "need a file name." << std::endl;
+      }
+    ////// command: name
+    } else if (elems[0].compare("name") == 0) {
+
+      std::cout << "The name of this index is: '" << index->getName() << "'" << std::endl;
+        
     ////// command: push
     } else if (elems[0].compare("push") == 0) {
 
@@ -171,96 +196,120 @@ int main(int argc, char** argv) {
 
       try {
 
-        // This illustrates one way to get the data out of the index.
-        // You can also do something like this:
-        //
-        //  int ip = index->getValue("henry", "/")
-        MinVR::VRDatumPtr p = index->getDatum(elems[1], nameSpace);
+        if ((elems.size() == 1) || (elems[1].compare("/") == 0)) {
 
-        switch (p->getType()) {
-        case MinVR::VRCORETYPE_INT:
-          std::cout << "an integer containing: " << ((int)p->getValue()) << std::endl;
+          std::cout << "The entire index." << std::endl
+                    << "serialization: " << index->serialize() << std::endl;
 
-          std::cout << "same as: " << (int)index->getValue(elems[1], nameSpace) << std::endl;
-          break;
+        } else {
+        
+          // This illustrates one way to get the data out of the index.
+          // You can also do something like this:
+          //
+          //  int ip = index->getValue("henry", "/")
+          MinVR::VRDatumPtr p = index->getDatum(elems[1], nameSpace);
 
-        case MinVR::VRCORETYPE_FLOAT:
-          std::cout << "a float containing: " << ((float)p->getValue()) << std::endl;
-          break;
+          switch (p->getType()) {
+          case MinVR::VRCORETYPE_INT:
+            std::cout << "an integer containing: " << ((int)p->getValue()) << std::endl;
 
-        case MinVR::VRCORETYPE_STRING:
-          std::cout << "a string containing: " << ((std::string)p->getValue()) << std::endl;
-          break;
-
-        case MinVR::VRCORETYPE_INTARRAY:
-          {
-            MinVR::VRIntArray pdata = p->getValue();
-            for (MinVR::VRIntArray::iterator it = pdata.begin(); it != pdata.end(); ++it) {
-              std::cout << "element: " << *it << std::endl;
-            }
+            std::cout << "same as: " << (int)index->getValue(elems[1], nameSpace) << std::endl;
             break;
+
+          case MinVR::VRCORETYPE_FLOAT:
+            std::cout << "a float containing: " << ((float)p->getValue()) << std::endl;
+            break;
+
+          case MinVR::VRCORETYPE_STRING:
+            std::cout << "a string containing: " << ((std::string)p->getValue()) << std::endl;
+            break;
+
+          case MinVR::VRCORETYPE_INTARRAY:
+            {
+              MinVR::VRIntArray pdata = p->getValue();
+              for (MinVR::VRIntArray::iterator it = pdata.begin(); it != pdata.end(); ++it) {
+                std::cout << "element: " << *it << std::endl;
+              }
+              break;
+            }
+
+          case MinVR::VRCORETYPE_FLOATARRAY:
+            {
+              MinVR::VRFloatArray pdata = p->getValue();
+              for (MinVR::VRFloatArray::iterator it = pdata.begin(); it != pdata.end(); ++it) {
+                std::cout << "element: " << *it << std::endl;
+              }
+              break;
+            }
+
+          case MinVR::VRCORETYPE_STRINGARRAY:
+            {
+              MinVR::VRStringArray pdata = p->getValue();
+              for (MinVR::VRStringArray::iterator it = pdata.begin(); it != pdata.end(); ++it) {
+                std::cout << "element: " << *it << std::endl;
+              }
+              break;
+            }
+
+          case MinVR::VRCORETYPE_CONTAINER:
+
+            {
+              std::cout << "a container containing: " << std::endl;
+
+              MinVR::VRContainer nameList = p->getValue();
+              for (MinVR::VRContainer::iterator nl = nameList.begin();
+                   nl != nameList.end(); nl++) {
+                std::cout << "                        " << *nl << std::endl;
+              }
+              break;
+            }
+
+          case MinVR::VRCORETYPE_NONE:
+            {
+              break;
+            }	     
           }
 
-        case MinVR::VRCORETYPE_FLOATARRAY:
-          {
-            MinVR::VRFloatArray pdata = p->getValue();
-            for (MinVR::VRFloatArray::iterator it = pdata.begin(); it != pdata.end(); ++it) {
-              std::cout << "element: " << *it << std::endl;
-            }
-            break;
-          }
-
-        case MinVR::VRCORETYPE_STRINGARRAY:
-          {
-            MinVR::VRStringArray pdata = p->getValue();
-            for (MinVR::VRStringArray::iterator it = pdata.begin(); it != pdata.end(); ++it) {
-              std::cout << "element: " << *it << std::endl;
-            }
-            break;
-          }
-
-        case MinVR::VRCORETYPE_CONTAINER:
-
-          {
-            std::cout << "a container containing: " << std::endl;
-
-            MinVR::VRContainer nameList = p->getValue();
-            for (MinVR::VRContainer::iterator nl = nameList.begin();
-                 nl != nameList.end(); nl++) {
-              std::cout << "                        " << *nl << std::endl;
-            }
-            break;
-          }
-
-        case MinVR::VRCORETYPE_NONE:
-          {
-            break;
-          }	     
+          std::cout << "serialization: " << index->serialize(elems[1], nameSpace) << std::endl;
         }
-
-        std::cout << "serialization: " << index->serialize(elems[1], nameSpace) << std::endl;
+          
       } catch (const std::exception& e) {
 
         std::cout << "oops: " << e.what() << std::endl;
 
       }
 
-    ////// command: l (list all values)
+    ////// command: ls (list all values)
     } else if (elems[0].compare("ls") == 0) {
 
-      MinVR::VRContainer nameList;
-      if (elems.size() > 1) {
-        nameList = index->getValue(elems[1]);
-      } else {
-        if (nameSpace.compare("/") == 0) {
-          nameList = index->getNames();
+      try {
+        MinVR::VRContainer nameList;
+        if (elems.size() > 1) {
+
+          if (elems[1].compare("/") == 0) {
+
+            // We want the root list of names.
+            nameList = index->getNames();
+          } else {
+
+            // Get the list for the specified container.
+            nameList = index->getValue(elems[1]);
+          }
         } else {
-          nameList = index->getValue(nameSpace.substr(0,nameSpace.size() - 1));
+          if (nameSpace.compare("/") == 0) {
+            nameList = index->getNames();
+          } else {
+            nameList = index->getValue(nameSpace.substr(0,nameSpace.size() - 1));
+          }
         }
-      }
-      for (MinVR::VRContainer::iterator it = nameList.begin();
-           it != nameList.end(); it++) {
-        std::cout << *it << std::endl;
+        for (MinVR::VRContainer::iterator it = nameList.begin();
+             it != nameList.end(); it++) {
+          std::cout << *it << std::endl;
+        }
+      } catch(const std::exception& e) {
+
+        std::cout << "oops: " << e.what() << std::endl;
+
       }
     ////// command: add (add something)
     } else if (elems[0].compare("add") == 0) {


### PR DESCRIPTION
This change accomplishes a few things:

1. A data index now has a "name" which is "MVR" by default. There are accessor and setter methods too.

2. A data index can be initialized with a constructor that takes a serialized string. With this constructor, the root element of the serialized string becomes the name of the data index, and its children appear at the "root" level of the data index.

3. There is a "serialize()" method, with no argument, that serialized the entire index, using the name of the index as the root of the serialized string.

4. An index test was added to check up on this feature.