### PR TITLE
fixed VRSearchPath to have INSTALLPATH inserted at cmake-time

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,33 +1,33 @@
 # ================================================================================
-# 
+#
 # This file is part of the MinVR project.
-# 
+#
 # File: CMakeLists.txt
-# 
+#
 # Original Author(s) of this File:
 # 	MinVR Core Team
-# 
+#
 # Author(s) of Significant Updates/Modifications to the File:
 # 	...
-# 
+#
 # -----------------------------------------------------------------------------------
 # Copyright (c) 2015 Regents of the University of Minnesota and Brown University
 # All rights reserved.
-# 
+#
 # Redistribution and use in source and binary forms, with or without modification,
 # are permitted provided that the following conditions are met:
-# 
+#
 # * Redistributions of source code must retain the above copyright notice, this
 #   list of conditions and the following disclaimer.
-# 
+#
 # * Redistributions in binary form must reproduce the above copyright notice, this
 #   list of conditions and the following disclaimer in the documentation and/or
 #   other materials provided with the distribution.
-# 
+#
 # * The name of the University of Minnesota, nor the names of its
 #   contributors may be used to endorse or promote products derived from
 #   this software without specific prior written permission.
-# 
+#
 # THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
 # ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
 # WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
@@ -38,7 +38,7 @@
 # ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
 # (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
 # SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-# ================================================================================ 
+# ================================================================================
 
 
 project(libMinVR)
@@ -158,6 +158,16 @@ set(vr_main_cpp
   ${vr_src_dir}/main/VRSystem.cpp
 )
 
+## This is executed at cmake-time, and is done in order to sneak the
+## MinVR install directory literal into the VRSearchPath header file.
+## This does mess up the out-of-source build protocol, since the
+## VRSearchPath.h header file is not really source any more, but it
+## seems worth it.
+set(CMAKE_NO_EDIT_WARNING "WARNING -- THIS IS A GENERATED FILE -- DO NOT EDIT")
+configure_file(
+  ${CMAKE_CURRENT_SOURCE_DIR}/main/VRSearchPath.hpp
+  ${CMAKE_CURRENT_SOURCE_DIR}/main/VRSearchPath.h)
+
 set(vr_main_h
   ${vr_src_dir}/main/VRAppLauncher.h
   ${vr_src_dir}/main/VREventHandler.h
@@ -170,6 +180,7 @@ set(vr_main_h
   ${vr_src_dir}/main/VRMain.h
   ${vr_src_dir}/main/VRMainInterface.h
   ${vr_src_dir}/main/VRRenderHandler.h
+  ${vr_src_dir}/main/VRSearchPath.h
   ${vr_src_dir}/main/VRSystem.h
 )
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -155,18 +155,9 @@ set(vr_main_cpp
   ${vr_src_dir}/main/VRGraphicsStateInternal.cpp
   ${vr_src_dir}/main/VRLocalAppLauncher.cpp
   ${vr_src_dir}/main/VRMain.cpp
+  ${vr_src_dir}/main/VRSearchPath.cpp
   ${vr_src_dir}/main/VRSystem.cpp
 )
-
-## This is executed at cmake-time, and is done in order to sneak the
-## MinVR install directory literal into the VRSearchPath header file.
-## This does mess up the out-of-source build protocol, since the
-## VRSearchPath.h header file is not really source any more, but it
-## seems worth it.
-set(CMAKE_NO_EDIT_WARNING "WARNING -- THIS IS A GENERATED FILE -- DO NOT EDIT")
-configure_file(
-  ${CMAKE_CURRENT_SOURCE_DIR}/main/VRSearchPath.hpp
-  ${CMAKE_CURRENT_SOURCE_DIR}/main/VRSearchPath.h)
 
 set(vr_main_h
   ${vr_src_dir}/main/VRAppLauncher.h

--- a/src/main/VRSearchPath.cpp
+++ b/src/main/VRSearchPath.cpp
@@ -1,0 +1,111 @@
+#include "VRSearchPath.h"
+
+namespace MinVR {
+
+void VRSearchPath::addPathEntry(const std::string &pathEntry, bool start) {
+
+  std::string entry;
+  // Unpack any environment variables.  If they're in the entry, but not
+  // defined, ignore the entry and get out.
+  try {
+    entry = VRDataIndex::dereferenceEnvVars(pathEntry);
+  } catch (...) {
+    return;
+  }
+
+  if (start) {
+    _searchPath.push_front(entry);
+  } else {
+    _searchPath.push_back(entry);
+  }
+}
+
+void VRSearchPath::digestPathString(const std::string &searchList) {
+
+  // If the searchList already has stuff in it, put this list at the beginning.
+  std::list<std::string> newList;
+
+  std::stringstream ss(searchList);
+  std::string singlePath;
+  while (std::getline(ss, singlePath, ':')) {
+    // Add them to the end of the line.
+    newList.push_back(singlePath);
+  }
+
+  if (_searchPath.empty()) {
+    _searchPath = newList;
+  } else {
+    _searchPath.insert(_searchPath.begin(), newList.begin(), newList.end());
+  }
+}
+
+std::string VRSearchPath::findFile(const std::string &desiredFile) {
+  for (std::list<std::string>::iterator it = _searchPath.begin();
+       it != _searchPath.end(); it++) {
+    std::string testFile = _selectFile(desiredFile, (*it));
+    if (open(testFile.c_str(), O_RDONLY) >= 0)
+      return testFile;
+  }
+  return "";
+}
+
+std::string VRSearchPath::getPath() const {
+
+  std::string out;
+  for (std::list<std::string>::const_iterator it = _searchPath.begin();
+       it != _searchPath.end(); it++)
+    out += (*it) + ":";
+
+  return out.substr(0, out.length() - 1);
+}
+
+///
+// Here is the search path order that MinVR searches for plugins:
+//
+//    1. Plugin path specified in config ("/PluginPath" in VRDataIndex)
+//    2. Working directory (".")
+//    3. <Working directory>/plugins ("./plugins")
+//    4. Custom user defined paths (i.e. vrmain->addPluginSearchPath(mypath))
+//    5. <Binary directory>/../plugins ("build/bin/../plugins")
+//    6. <Install directory>/plugins ("install/plugins")
+//    7. <$MINVR_ROOT>/plugins ("$MINVR_ROOT/plugins")
+VRSearchPlugin::VRSearchPlugin() {
+
+  // 1. current working directory
+  addPathEntry("./", false);
+
+  // 2. config subdir within current working directory
+  addPathEntry("./plugins/", false);
+
+  // 3. running from within the build tree from build/bin or tests-*/testname
+  addPathEntry("../plugins/", false);
+
+  // 4. an installed version based on MINVR_ROOT envvar
+  addPathEntry("${MINVR_ROOT}/plugins/", false);
+
+  // 5. an installed version based on the INSTALL_PREFIX set with cmake
+  addPathEntry(std::string(INSTALLPATH) + "/plugins", false);
+
+}
+
+/// Same as VRSearchPath, but built to accommodate the specific semantics of
+/// the configuration file naming.
+VRSearchConfig::VRSearchConfig() {
+
+  // 1. current working directory
+  addPathEntry("./", false);
+
+  // 2. config subdir within current working directory
+  addPathEntry("./config/", false);
+
+  // 3. running from within the build tree from build/bin or tests-*/testname
+  addPathEntry("../../config/", false);
+
+  // 4. an installed version based on MINVR_ROOT envvar
+  addPathEntry("${MINVR_ROOT}/config/", false);
+
+  // 5. an installed version based on the INSTALL_PREFIX set with cmake
+  addPathEntry(std::string("${CMAKE_INSTALL_PREFIX}") + "/config/", false);
+}
+
+}

--- a/src/main/VRSearchPath.h
+++ b/src/main/VRSearchPath.h
@@ -41,73 +41,24 @@ class VRSearchPath {
   /// \param pathEntry The directory name to add.
   /// \param start A boolean value.  If true (default), add the entry at
   /// the beginning of the list.  Otherwise add it to the end.
-  void addPathEntry(const std::string &pathEntry, bool start = true) {
-
-    std::string entry;
-    // Unpack any environment variables.  If they're in the entry, but not
-    // defined, ignore the entry and get out.
-    try {
-      entry = MinVR::VRDataIndex::dereferenceEnvVars(pathEntry);
-    } catch (...) {
-      return;
-    }
-
-    if (start) {
-      _searchPath.push_front(entry);
-    } else {
-      _searchPath.push_back(entry);
-    }
-  };
+  void addPathEntry(const std::string &pathEntry, bool start = true);
 
   /// \brief Create a search path from a single string.
   ///
   /// Adds a whole path from one colon-separated string.
-  void digestPathString(const std::string &searchList) {
-
-    // If the searchList already has stuff in it, put this list at the beginning.
-    std::list<std::string> newList;
-
-    std::stringstream ss(searchList);
-    std::string singlePath;
-    while (std::getline(ss, singlePath, ':')) {
-      // Add them to the end of the line.
-      newList.push_back(singlePath);
-    }
-
-    if (_searchPath.empty()) {
-      _searchPath = newList;
-    } else {
-      _searchPath.insert(_searchPath.begin(), newList.begin(), newList.end());
-    }
-  };
+  void digestPathString(const std::string &searchList);
 
   /// \brief Find a file.
   ///
   /// \return Returns a fully-resolved path name of the file in question,
   /// wherever it lies on the search path.  If the file is not found, the
   /// return value is empty.
-  std::string findFile(const std::string &desiredFile) {
-    for (std::list<std::string>::iterator it = _searchPath.begin();
-         it != _searchPath.end(); it++) {
-      std::string testFile = _selectFile(desiredFile, (*it));
-      if (open(testFile.c_str(), O_RDONLY) >= 0)
-        return testFile;
-    }
-    return "";
-  }
+  std::string findFile(const std::string &desiredFile);
 
   /// \brief Return path as a single string.
   ///
   /// Returns the search path as a single colon-separated string.
-  std::string getPath() const {
-
-    std::string out;
-    for (std::list<std::string>::const_iterator it = _searchPath.begin();
-         it != _searchPath.end(); it++)
-      out += (*it) + ":";
-
-    return out.substr(0, out.length() - 1);
-  }
+  std::string getPath() const;
 
   friend std::ostream &operator<<(std::ostream &os, const VRSearchPath &p) {
     return os << p.getPath();
@@ -150,35 +101,7 @@ class VRSearchPlugin : public VRSearchPath {
   }
 
  public:
-  ///
-  // Here is the search path order that MinVR searches for plugins:
-	//
-  //    1. Plugin path specified in config ("/PluginPath" in VRDataIndex)
-  //    2. Working directory (".")
-  //    3. <Working directory>/plugins ("./plugins")
-  //    4. Custom user defined paths (i.e. vrmain->addPluginSearchPath(mypath))
-  //    5. <Binary directory>/../plugins ("build/bin/../plugins")
-  //    6. <Install directory>/plugins ("install/plugins")
-  //    7. <$MINVR_ROOT>/plugins ("$MINVR_ROOT/plugins")
-  VRSearchPlugin() {
-
-    // 1. current working directory
-    addPathEntry("./", false);
-
-    // 2. config subdir within current working directory
-    addPathEntry("./plugins/", false);
-
-    // 3. running from within the build tree from build/bin or tests-*/testname
-    addPathEntry("../plugins/", false);
-
-    // 4. an installed version based on MINVR_ROOT envvar
-    addPathEntry("${MINVR_ROOT}/plugins/", false);
-
-    // 5. an installed version based on the INSTALL_PREFIX set with cmake
-    addPathEntry(std::string("${CMAKE_INSTALL_PREFIX}") + "/plugins", false);
-
-  }
-
+  VRSearchPlugin();
 };
 
 /// Same as VRSearchPath, but built to accommodate the specific semantics of
@@ -202,22 +125,8 @@ class VRSearchConfig : public VRSearchPath {
   };
 
  public:
-  VRSearchConfig() {
-    // 1. current working directory
-    addPathEntry("./", false);
-
-    // 2. config subdir within current working directory
-    addPathEntry("./config/", false);
-
-    // 3. running from within the build tree from build/bin or tests-*/testname
-    addPathEntry("../../config/", false);
-
-    // 4. an installed version based on MINVR_ROOT envvar
-    addPathEntry("${MINVR_ROOT}/config/", false);
-
-    // 5. an installed version based on the INSTALL_PREFIX set with cmake
-    addPathEntry(std::string("${CMAKE_INSTALL_PREFIX}") + "/config/", false);
-  }
+  // The actual search path is defined in the constructor.
+  VRSearchConfig();
 };
 
 }

--- a/src/main/VRSearchPath.hpp
+++ b/src/main/VRSearchPath.hpp
@@ -1,3 +1,4 @@
+// ${CMAKE_NO_EDIT_WARNING}
 #ifndef VRSEARCHPATH_H
 #define VRSEARCHPATH_H
 
@@ -174,7 +175,7 @@ class VRSearchPlugin : public VRSearchPath {
     addPathEntry("${MINVR_ROOT}/plugins/", false);
 
     // 5. an installed version based on the INSTALL_PREFIX set with cmake
-    addPathEntry(std::string(INSTALLPATH) + "/plugins", false);
+    addPathEntry(std::string("${CMAKE_INSTALL_PREFIX}") + "/plugins", false);
 
   }
 
@@ -215,7 +216,7 @@ class VRSearchConfig : public VRSearchPath {
     addPathEntry("${MINVR_ROOT}/config/", false);
 
     // 5. an installed version based on the INSTALL_PREFIX set with cmake
-    addPathEntry(std::string(INSTALLPATH) + "/config/", false);
+    addPathEntry(std::string("${CMAKE_INSTALL_PREFIX}") + "/config/", false);
   }
 };
 


### PR DESCRIPTION
This addresses a problem with the way VRSearchPath.h was handled before. I'd used "add_definitions" in cmake to include the install directories in the search path, and that worked for the library, but not for the installed header file to be used with the library. This fix removes VRSearchPath.h as a part of the source, and replaces it with VRSearchPath.hpp that is auto-edited to create the .h file. The auto-edit happens at cmake-time, so it's available at compile time.