### PR TITLE
Fixed minor Windows compile errors

### DIFF
--- a/src/config/VRDataIndex.cpp
+++ b/src/config/VRDataIndex.cpp
@@ -769,7 +769,7 @@ int VRDataIndex::isChild(const std::string &parentName,
 
   // Remove any trailing slashes on the parent name.
   std::string pName = parentName;
-  if (pName[pName.size() - 1] == '/') pName.erase(pName.size() - 1);
+  if (pName.size() > 0 && pName[pName.size() - 1] == '/') pName.erase(pName.size() - 1);
 
   // First check that the childName contains the pName, and is longer.
   int out = childName.compare(0, std::string::npos, pName) > 0;

--- a/src/main/VRSearchPath.h
+++ b/src/main/VRSearchPath.h
@@ -8,6 +8,12 @@
 #include <list>
 #include <fcntl.h>
 
+#ifdef WIN32
+#include <io.h> // Necessary for open() and write() support in windows
+#endif // WIN32
+
+
+
 #include <config/VRDataIndex.h>
 
 namespace MinVR {

--- a/tests-batch/main/utilitytest.cpp
+++ b/tests-batch/main/utilitytest.cpp
@@ -158,10 +158,10 @@ int testSearchPath() {
   out += spc.findFile("Chester.xml").compare("testSearch/test2/test3/Chester.xml");
 
   std::cout << "spc:" << spc.findFile("Chester.xml") << " out:" << out << std::endl;
+  
+  executeShellCommand("rm -rf testSearch");
 
 #endif
-
-  executeShellCommand("rm -rf testSearch");
 
   return out;
 }


### PR DESCRIPTION
The io.h library on windows adds support for unix open() commands, which MinVR uses in VRSearchPath. Also, there was an executeShellCommand that was being run in one of the tests.