### PR TITLE
Minnie -- fixes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -84,7 +84,6 @@ else()
 endif()
 
 set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} -DMinVR_DEBUG")
-add_definitions(-DINSTALLPATH="${CMAKE_INSTALL_PREFIX}")
 
 make_directory(${CMAKE_BINARY_DIR}/lib)
 make_directory(${CMAKE_BINARY_DIR}/bin)
@@ -97,6 +96,10 @@ foreach (CONF ${CMAKE_CONFIGURATION_TYPES})
   set (CMAKE_ARCHIVE_OUTPUT_DIRECTORY_${CONF} ${CMAKE_BINARY_DIR}/lib)
   set (CMAKE_LIBRARY_OUTPUT_DIRECTORY_${CONF} ${CMAKE_BINARY_DIR}/lib)
 endforeach(CONF CMAKE_CONFIGURATION_TYPES)
+
+## Some definitions to use in the code for convenience.
+add_definitions(-DINSTALLPATH="${CMAKE_INSTALL_PREFIX}")
+add_definitions(-DBINARYPATH="${CMAKE_RUNTIME_OUTPUT_DIRECTORY}")
 
 
 if (${CMAKE_SYSTEM_NAME} MATCHES "Linux")

--- a/plugins/GLFW/src/VRGLFWInputDevice.cpp
+++ b/plugins/GLFW/src/VRGLFWInputDevice.cpp
@@ -21,34 +21,34 @@ static void glfw_key_callback(GLFWwindow* window, int key, int scancode,
     ((VRGLFWInputDevice*)(glfwGetWindowUserPointer(window)))->keyCallback(window, key, scancode, action, mods);
 }
 
-  
+
 static void glfw_size_callback(GLFWwindow* window, int width, int height) {
     ((VRGLFWInputDevice*)(glfwGetWindowUserPointer(window)))->sizeCallback(window, width, height);
 }
 
-  
+
 static void glfw_cursor_position_callback(GLFWwindow* window, double xpos, double ypos) {
     ((VRGLFWInputDevice*)(glfwGetWindowUserPointer(window)))->cursorPositionCallback(window, xpos, ypos);
 }
 
-  
+
 static void glfw_mouse_button_callback(GLFWwindow* window, int button, int action, int mods) {
   ((VRGLFWInputDevice*)(glfwGetWindowUserPointer(window)))->mouseButtonCallback(window, button, action, mods);
 }
 
-  
+
 VRGLFWInputDevice::VRGLFWInputDevice() {
 }
 
 VRGLFWInputDevice::~VRGLFWInputDevice() {
 }
 
-void VRGLFWInputDevice::appendNewInputEventsSinceLastCall(std::vector<VRDataIndex> *events) {
+void VRGLFWInputDevice::appendNewInputEventsSinceLastCall(VRDataQueue* queue) {
     glfwPollEvents();
 
     for (int f = 0; f < _events.size(); f++)
     {
-    	events->push_back(_events[f]);
+    	queue->push(_events[f].serialize());
     }
 
     _events.clear();
@@ -88,18 +88,18 @@ void VRGLFWInputDevice::cursorPositionCallback(GLFWwindow* window, float xpos, f
     pos.push_back(xpos);
     pos.push_back(ypos);
     event.addData("Position", pos);
-    
+
     int width, height;
     glfwGetWindowSize(window, &width, &height);
     pos[0] /= (float)width;
     pos[1] /= (float)height;
     event.addData("NormalizedPosition", pos);
-    
+
     _events.push_back(event);
 }
 
-  
-  
+
+
 void VRGLFWInputDevice::mouseButtonCallback(GLFWwindow* window, int button, int action, int mods) {
   std::string buttonStr;
   if (button == GLFW_MOUSE_BUTTON_LEFT) {
@@ -116,7 +116,7 @@ void VRGLFWInputDevice::mouseButtonCallback(GLFWwindow* window, int button, int 
     os << button;
     buttonStr = "MouseBtn" + os.str() + "_";
   }
-  
+
   std::string actionStr;
   if (action == GLFW_PRESS) {
     actionStr = "Down";
@@ -132,10 +132,10 @@ void VRGLFWInputDevice::mouseButtonCallback(GLFWwindow* window, int button, int 
     _events.push_back(event);
 }
 
-  
-  
-  
-  
+
+
+
+
 std::string getGlfwKeyName(int key) {
     switch (key)
     {

--- a/plugins/GLFW/src/VRGLFWInputDevice.h
+++ b/plugins/GLFW/src/VRGLFWInputDevice.h
@@ -23,7 +23,7 @@
 
 namespace MinVR {
 
-/** A VRInputDevice that polls input events (mouse, keyboard, window resize, etc.) 
+/** A VRInputDevice that polls input events (mouse, keyboard, window resize, etc.)
     for all of the active GLFWWindows and returns input in MinVR event format.
  */
 class VRGLFWInputDevice : public VRInputDevice {
@@ -31,7 +31,7 @@ public:
 	PLUGIN_API VRGLFWInputDevice();
 	PLUGIN_API virtual ~VRGLFWInputDevice();
 
-    PLUGIN_API void appendNewInputEventsSinceLastCall(std::vector<VRDataIndex> *events);
+    PLUGIN_API void appendNewInputEventsSinceLastCall(VRDataQueue* queue);
 
     PLUGIN_API void addWindow(::GLFWwindow* window);
 	// TODO: removeWindow()?
@@ -42,7 +42,7 @@ public:
 	PLUGIN_API void sizeCallback(GLFWwindow* window, int width, int height);
     PLUGIN_API void cursorPositionCallback(GLFWwindow* window, float xpos, float ypos);
   	PLUGIN_API void mouseButtonCallback(GLFWwindow* window, int button, int action, int mods);
-  
+
 private:
 	std::vector<VRDataIndex> _events;
     std::vector< ::GLFWwindow*> _windows;

--- a/plugins/VRPN/src/VRVRPNAnalogDevice.cpp
+++ b/plugins/VRPN/src/VRVRPNAnalogDevice.cpp
@@ -1,14 +1,14 @@
 /* ================================================================================
 
-This file is part of the MinVR Open Source Project, which is developed and 
-maintained collaboratively by the University of Minnesota's Interactive 
+This file is part of the MinVR Open Source Project, which is developed and
+maintained collaboratively by the University of Minnesota's Interactive
 Visualization Lab and the Brown University Visualization Research Lab.
 
 File: VRVRPNAnalogDevice.cpp
 
-Original Author(s) of this File: 
+Original Author(s) of this File:
 	Daniel Keefe, 2004, Brown University (originally VRG3D/VRPNAnalogDevice.cpp)
-	
+
 Author(s) of Significant Updates/Modifications to the File:
 	Bret Jackson, 2013, University of Minnesota (adapted to MinVR)
 	Dan Keefe, 2016, University of Minnesota (adapted to MinVR2)
@@ -114,10 +114,8 @@ void VRVRPNAnalogDevice::sendEventIfChanged(int channelNumber, float data)
 void VRVRPNAnalogDevice::appendNewInputEventsSinceLastCall(VRDataQueue *inputEvents)
 {
 	_vrpnDevice->mainloop();
-	while (_pendingEvents.notEmpty()) {
-		inputEvents->push(_pendingEvents.getSerializedObject());
-		_pendingEvents.pop();
-	}
+  inputEvents->addQueue(_pendingEvents);
+  _pendingEvents.clear();
 }
 
 

--- a/plugins/VRPN/src/VRVRPNButtonDevice.cpp
+++ b/plugins/VRPN/src/VRVRPNButtonDevice.cpp
@@ -1,14 +1,14 @@
 /* ================================================================================
 
-This file is part of the MinVR Open Source Project, which is developed and 
-maintained collaboratively by the University of Minnesota's Interactive 
+This file is part of the MinVR Open Source Project, which is developed and
+maintained collaboratively by the University of Minnesota's Interactive
 Visualization Lab and the Brown University Visualization Research Lab.
 
 File: VRVRPNButtonDevice.cpp
 
-Original Author(s) of this File: 
+Original Author(s) of this File:
 	Daniel Keefe, 2004, Brown University (originally VRG3D/VRPNButtonDevice.cpp)
-	
+
 Author(s) of Significant Updates/Modifications to the File:
 	Bret Jackson, 2013, University of Minnesota (adapted to MinVR)
 	Dan Keefe, 2016, University of Minnesota (adapted to MinVR2)
@@ -110,13 +110,10 @@ void VRVRPNButtonDevice::sendEvent(int buttonNumber, bool down)
 	}
 }
 
-void VRVRPNButtonDevice::appendNewInputEventsSinceLastCall(VRDataQueue *inputEvents)
-{
+void VRVRPNButtonDevice::appendNewInputEventsSinceLastCall(VRDataQueue *inputEvents) {
 	_vrpnDevice->mainloop();
-	while (_pendingEvents.notEmpty()) {
-		inputEvents->push(_pendingEvents.getSerializedObject());
-		_pendingEvents.pop();
-	}
+  inputEvents->addQueue(_pendingEvents);
+  _pendingEvents.clear();
 }
 
 

--- a/plugins/VRPN/src/VRVRPNTrackerDevice.cpp
+++ b/plugins/VRPN/src/VRVRPNTrackerDevice.cpp
@@ -1,14 +1,14 @@
 /* ================================================================================
 
-This file is part of the MinVR Open Source Project, which is developed and 
-maintained collaboratively by the University of Minnesota's Interactive 
+This file is part of the MinVR Open Source Project, which is developed and
+maintained collaboratively by the University of Minnesota's Interactive
 Visualization Lab and the Brown University Visualization Research Lab.
 
 File: VRVRPNTrackerDevice.cpp
 
-Original Author(s) of this File: 
+Original Author(s) of this File:
 	Daniel Keefe, 2004, Brown University (originally VRG3D/VRPNTrackerDevice.cpp)
-	
+
 Author(s) of Significant Updates/Modifications to the File:
 	Bret Jackson, 2013, University of Minnesota (adapted to MinVR)
 	Dan Keefe, 2016, University of Minnesota (adapted to MinVR2)
@@ -78,7 +78,7 @@ void VRPN_CALLBACK trackerHandler(void *thisPtr, const vrpn_TRACKERCB info)
     vrpnEvent(0,3) = info.pos[0];
     vrpnEvent(1,3) = info.pos[1];
     vrpnEvent(2,3) = info.pos[2];
-  
+
 	VRVRPNTrackerDevice* device = ((VRVRPNTrackerDevice*)thisPtr);
 	device->processEvent(vrpnEvent, info.sensor);
 }
@@ -194,7 +194,7 @@ std::string VRVRPNTrackerDevice::getEventName(int trackerNumber)
 		return _eventNames[trackerNumber];
 }
 
-  
+
 void VRVRPNTrackerDevice::appendNewInputEventsSinceLastCall(VRDataQueue *inputEvents)
 {
   // If this poll routine isn't called fast enough then the UDP buffer can fill up and
@@ -212,17 +212,15 @@ void VRVRPNTrackerDevice::appendNewInputEventsSinceLastCall(VRDataQueue *inputEv
     _vrpnDevice->mainloop();
   }
 
-  while (_pendingEvents.notEmpty()) {
-    inputEvents->push(_pendingEvents.getSerializedObject());
-    _pendingEvents.pop();
-  }
+  inputEvents->addQueue(_pendingEvents);
+  _pendingEvents.clear();
 }
-  
+
 
 VRInputDevice*
 VRVRPNTrackerDevice::create(VRMainInterface *vrMain, VRDataIndex *config, const std::string &nameSpace) {
   std::string devNameSpace = nameSpace;
-    
+
   std::string vrpnName = config->getValue("VRPNDeviceName", devNameSpace);
   std::vector<std::string> eventsToGenerate = config->getValue("EventsToGenerate", devNameSpace);
   double scale = config->getValue("TrackerUnitsToRoomUnitsScale", devNameSpace);
@@ -231,13 +229,13 @@ VRVRPNTrackerDevice::create(VRMainInterface *vrMain, VRDataIndex *config, const 
   bool wait = ((int)config->getValue("WaitForNewReportInPoll", nameSpace)) == 1;
   bool convert = ((int)config->getValue("ConvertLHtoRH", nameSpace)) == 1;
   bool ignore = ((int)config->getValue("IgnoreZeroes", nameSpace)) == 1;
-  
-  
+
+
   std::vector<VRMatrix4> p2t;
   std::vector<VRMatrix4> fo;
   for (int  i = 0; i < eventsToGenerate.size(); i++) {
 	  std::string trackerNameSpace = config->validateNameSpace(nameSpace) + eventsToGenerate[i] + "/";
-    
+
     VRMatrix4 m = config->getValue("PropToTracker", trackerNameSpace);
     m = m.orthonormal();
     p2t.push_back(m);
@@ -245,13 +243,13 @@ VRVRPNTrackerDevice::create(VRMainInterface *vrMain, VRDataIndex *config, const 
     m = m.orthonormal();
     fo.push_back(m);
   }
-  
+
   VRInputDevice *dev = new VRVRPNTrackerDevice(vrpnName, eventsToGenerate, scale,
                                                d2r, p2t, fo, wait, convert, ignore);
   return dev;
 }
 
-  
+
 } // end namespace
 
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -153,7 +153,7 @@ set(vr_api_h
   ${vr_src_dir}/api/VRAnalogState.h
   ${vr_src_dir}/api/VRAudioState.h
   ${vr_src_dir}/api/VRButtonState.h
-  ${vr_src_dir}/api/VRConsoleState.h  
+  ${vr_src_dir}/api/VRConsoleState.h
   ${vr_src_dir}/api/VRCursorState.h
   ${vr_src_dir}/api/VRGraphicsState.h
   ${vr_src_dir}/api/VRHapticsState.h

--- a/src/config/VRDataIndex.cpp
+++ b/src/config/VRDataIndex.cpp
@@ -1257,6 +1257,9 @@ std::string VRDataIndex::printStructure(const std::string itemName,
 
     bool printMe = true;
 
+    // If we're printing the entire index, prepend the index name.
+    if (itemName.compare("/") == 0) outBuffer += _indexName + "\n";
+
     // Get the pieces of the current name.
     std::vector<std::string> elems = _explodeName( it->first );
     if (elems.size() == 0) continue;

--- a/src/config/VRDataIndex.cpp
+++ b/src/config/VRDataIndex.cpp
@@ -26,6 +26,14 @@ VRDatumFactory VRDataIndex::_factory = VRDataIndex::_initializeFactory();
 VRDataIndex::VRDataIndex(const std::string serializedData)  :
   _indexName("MVR"), _overwrite(1), _linkNeeded(false) {
 
+  // If this is just a name, we just need an empty data index with the
+  // given name.
+  if (serializedData[0] != '<') {
+    _indexName = serializedData;
+    return;
+  }
+
+  // If you're here, the input data looks like XML. So parse it.
   Cxml *xml = new Cxml();
   xml->parse_string((char*)serializedData.c_str());
   element *xml_node = xml->get_root_element();
@@ -920,64 +928,64 @@ VRDataIndex::_getEntry(const std::string &key,
     return _theIndex.end();
   }
 }
-    
+
 // non-const version
 VRDataIndex::VRDataMap::iterator
 VRDataIndex::_getEntry(const std::string &key,
                        const std::string nameSpace,
                        const bool inherit) {
-    
+
     VRDataMap::iterator outIt;
-    
+
     // If the input key begins with a "/", it is a fully qualified
     // name already.  That is, it already includes the name space.
     if (key[0] == '/') {
-        
+
         return _theIndex.find(key);
-        
+
     } else {
-        
+
         // If you're asking whether a fully-qualified name works, you want
         // a yes or no.  If you're asking about a relative name, you will
         // accept a name defined in a namespace senior to the one
         // specified.  So answering the query for an entry to match the
         // given name requires looking through the senior namespaces.
-        
+
         std::string validatedNameSpace = validateNameSpace(nameSpace);
-        
+
         // If inheritance is turned off, just check if this name exists.
         if (!inherit) return _theIndex.find(validatedNameSpace + key);
-        
+
         // Separate the name space into its constituent elements.
         std::vector<std::string> elems = _explodeName(validatedNameSpace);
-        
+
         // We start from the longest name space and peel off the rightmost
         // element each iteration until we find a match, or not.  This
         // provides for the most local version of key to prevail.  The
         // last iteration creates an empty testSpace, on purpose, to test
         // the root level nameSpace.
         for (int N = elems.size(); N >= 0; --N) {
-            
+
             std::vector<std::string> names(&elems[0], &elems[0] + N);
             std::string testSpace;
-            
+
             for (std::vector<std::string>::iterator it = names.begin();
                  it != names.end(); ++it) {
-                
+
                 testSpace += *it + "/" ;
             }
-            
+
             outIt = _theIndex.find(testSpace + key);
             if (outIt != _theIndex.end()) {
                 return outIt;
             }
         }
-        
+
         // If we are here, there is no matching name in the index.
         return _theIndex.end();
     }
 }
-    
+
 
 std::string VRDataIndex::getFullKey(const std::string &key,
                                     const std::string nameSpace,
@@ -1005,14 +1013,14 @@ VRDatumPtr VRDataIndex::_getDatum(const std::string &key,
     return p->second;
   }
 }
-    
+
 // Returns the data object for this name.
 const VRDatumPtr VRDataIndex::_getDatum(const std::string &key,
                                   const std::string nameSpace,
                                   const bool inherit) const {
-    
+
     VRDataMap::const_iterator p = _getEntry(key, nameSpace, inherit);
-    
+
     if (p == _theIndex.end()) {
         VRERRORNOADV("Never heard of " + key + " in namespace " + nameSpace);
     } else {

--- a/src/config/VRDataIndex.h
+++ b/src/config/VRDataIndex.h
@@ -1106,11 +1106,11 @@ private:
   VRDataMap::iterator _getEntry(const std::string &key,
                                 const std::string nameSpace = "",
                                 const bool inherit = true);
-    
+
   VRDataMap::const_iterator _getEntry(const std::string &key,
                                       const std::string nameSpace = "",
                                       const bool inherit = true) const;
-    
+
   // Returns a pointer to the value with a given name (and namespace)
   VRDatumPtr _getDatum(const std::string &key,
                        const std::string nameSpace = "",
@@ -1205,6 +1205,10 @@ private:
 
   // If this is false, we don't need to do linkNodes() or linkContent().
   bool _linkNeeded;
+
+  friend std::ostream & operator<<(std::ostream &os, const VRDataIndex& di) {
+    return os << di.printStructure();
+  }
 };
 
 

--- a/src/config/VRDataIndex.h
+++ b/src/config/VRDataIndex.h
@@ -1215,6 +1215,13 @@ private:
   }
 };
 
+/// \brief A class to hold an arbitrary event.
+///
+/// An event in MinVR is just a VRDataIndex object.
+typedef VRDataIndex VRRawEvent;
+
+
+
 
 // Where are we going with this: We have an index that contains
 // pointers to more-or-less arbitrary data types, yay.  On the to-do

--- a/src/config/VRDataIndex.h
+++ b/src/config/VRDataIndex.h
@@ -405,6 +405,10 @@ public:
   /// And another that fills an index with some serialized data.  The
   /// root name in the serialized data is adopted as the '_indexName' field
   /// of the index object.
+  ///
+  /// If the input data is just a simple string with no XML features
+  /// (i.e. it does not begin with a '<') then just create an empty
+  /// index with the given name.
   VRDataIndex(const std::string serializedData);
 
   /// \brief Makes a deep copy.

--- a/src/config/VRDataQueue.cpp
+++ b/src/config/VRDataQueue.cpp
@@ -108,7 +108,7 @@ void VRDataQueue::clear() {
 // makes lots of events have the same time stamp.
 
 
-void VRDataQueue::push(const VRDataQueue::serialData serializedData) {
+long long VRDataQueue::makeTimeStamp() {
 
 #ifdef WIN32
 	LARGE_INTEGER frequency;        // ticks per second
@@ -129,18 +129,21 @@ void VRDataQueue::push(const VRDataQueue::serialData serializedData) {
 
 #endif
 
-  push(timeStamp, serializedData);
+  return timeStamp;
+}
+
+void VRDataQueue::push(const VRDataQueue::serialData serializedData) {
+  push(makeTimeStamp(), serializedData);
+}
+
+void VRDataQueue::push(const VRDataIndex event) {
+  VRDataIndex* eventPtr = new VRDataIndex(event);
+  push(makeTimeStamp(), VRDataQueueItem(eventPtr));
 }
 
 void VRDataQueue::push(const long long timeStamp,
                        const VRDataQueue::serialData serializedData) {
-
-  VRTimeStamp testStamp = VRTimeStamp(timeStamp, 0);
-  while (dataMap.find(testStamp) != dataMap.end()) {
-    testStamp = VRTimeStamp(timeStamp, testStamp.second + 1);
-  }
-
-  dataMap.insert(VRDataListItem(testStamp, VRDataQueueItem(serializedData)));
+  push(timeStamp, VRDataQueueItem(serializedData));
 }
 
 void VRDataQueue::push(const long long timeStamp,

--- a/src/config/VRDataQueue.cpp
+++ b/src/config/VRDataQueue.cpp
@@ -79,7 +79,7 @@ VRDataIndex VRDataQueue::getFirst() const {
     return VRDataIndex();
   } else {
 
-    return _dataMap.begin()->second.getValue();
+    return _dataMap.begin()->second.getData();
   }
 }
 

--- a/src/config/VRDataQueue.cpp
+++ b/src/config/VRDataQueue.cpp
@@ -62,29 +62,33 @@ void VRDataQueue::addSerializedQueue(const VRDataQueue::serialData serializedQue
 
 void VRDataQueue::addQueue(const VRDataQueue newQueue) {
 
-  while (newQueue.notEmpty()) {
+  if (newQueue.notEmpty()) {
 
-    VRDataListItem p = newQueue.getFirstItem();
-    push(p.first.first, p.second);
+    for (VRDataQueue::const_iterator it = newQueue.begin();
+         it != newQueue.end(); it++) {
+      // We only want the time value of the timestamp, not the disambiguation
+      // value.
+      push(it->first.first, it->second);
+    }
   }
 }
 
 VRDataIndex VRDataQueue::getFirst() const {
-  if (dataMap.empty()) {
+  if (_dataMap.empty()) {
 
     return VRDataIndex();
   } else {
 
-    return dataMap.begin()->second.getValue();
+    return _dataMap.begin()->second.getValue();
   }
 }
 
 void VRDataQueue::pop() {
-  dataMap.erase(dataMap.begin());
+  _dataMap.erase(_dataMap.begin());
 }
 
 void VRDataQueue::clear() {
-  dataMap.clear();
+  _dataMap.clear();
 }
 
 // Suggested on Stackoverflow:
@@ -150,23 +154,23 @@ void VRDataQueue::push(const long long timeStamp,
                        const VRDataQueueItem queueItem) {
 
   VRTimeStamp testStamp = VRTimeStamp(timeStamp, 0);
-  while (dataMap.find(testStamp) != dataMap.end()) {
+  while (_dataMap.find(testStamp) != _dataMap.end()) {
     testStamp = VRTimeStamp(timeStamp, testStamp.second + 1);
   }
 
-  dataMap.insert(VRDataListItem(testStamp, queueItem));
+  _dataMap.insert(VRDataListItem(testStamp, queueItem));
 }
 
 
 VRDataQueue::serialData VRDataQueue::serialize() {
 
   std::ostringstream lenStr;
-  lenStr << dataMap.size();
+  lenStr << _dataMap.size();
 
   VRDataQueue::serialData out;
 
   out = "<VRDataQueue num=\"" + lenStr.str() + "\">";
-  for (VRDataList::iterator it = dataMap.begin(); it != dataMap.end(); ++it) {
+  for (VRDataList::iterator it = _dataMap.begin(); it != _dataMap.end(); ++it) {
     std::ostringstream timeStamp;
     timeStamp << it->first.first << "-" << std::setfill('0') << std::setw(3) << it->first.second;
     out += "<VRDataQueueItem timeStamp=\"" + timeStamp.str() + "\">" +
@@ -184,7 +188,7 @@ std::string VRDataQueue::printQueue() {
 
   char buf[3];
   int i = 0;
-  for (VRDataList::iterator it = dataMap.begin(); it != dataMap.end(); ++it) {
+  for (VRDataList::iterator it = _dataMap.begin(); it != _dataMap.end(); ++it) {
     sprintf(buf, "%d", ++i);
     out += "element " + std::string(buf) + ": " + it->second.serialize() + "\n";
   }

--- a/src/config/VRDataQueue.cpp
+++ b/src/config/VRDataQueue.cpp
@@ -182,15 +182,22 @@ VRDataQueue::serialData VRDataQueue::serialize() {
 }
 
 // DEBUG only
-std::string VRDataQueue::printQueue() {
+std::string VRDataQueue::printQueue() const {
 
   std::string out;
 
-  char buf[3];
+  char buf[6];  // No queues more than a million entries long.
   int i = 0;
-  for (VRDataList::iterator it = _dataMap.begin(); it != _dataMap.end(); ++it) {
+  for (VRDataList::const_iterator it = _dataMap.begin();
+       it != _dataMap.end(); ++it) {
     sprintf(buf, "%d", ++i);
-    out += "element " + std::string(buf) + ": " + it->second.serialize() + "\n";
+    std::string identifier = "element";
+    if (it->second.isSerialized()) {
+      identifier += "*";
+    } else {
+      identifier += " ";
+    }
+    out += identifier + std::string(buf) + ": " + it->second.serialize() + "\n";
   }
 
   return out;

--- a/src/config/VRDataQueue.h
+++ b/src/config/VRDataQueue.h
@@ -67,6 +67,7 @@ public:
   /// This is mostly for debugging, perhaps just for the curious.
   bool isSerialized() const { return (_dataIndex == NULL); };
 
+  /// \brief Return the serialized version of this queue item.
   std::string serialize() const {
     if (_dataIndex) {
       return _dataIndex->serialize();
@@ -75,7 +76,8 @@ public:
     }
   }
 
-  VRDataIndex getValue() const {
+  /// \brief Return the data index version of this queue item.
+  VRDataIndex getData() const {
     if (_dataIndex) {
       return *_dataIndex;
     } else {

--- a/src/config/VRDataQueue.h
+++ b/src/config/VRDataQueue.h
@@ -132,6 +132,9 @@ public:
   /// Removes all the objects in the queue.
   void clear();
 
+  /// Makes a timestamp from system facilities.
+  long long makeTimeStamp();
+
   /// Adds an event to the queue.
   void push(const VRDataIndex event);
   /// Adds a serialized event to the queue.

--- a/src/config/VRDataQueue.h
+++ b/src/config/VRDataQueue.h
@@ -174,25 +174,38 @@ private:
 
 
 public:
+
+  /// \brief Create an empty queue.
   VRDataQueue() {};
+
+  /// \brief Create a queue from serialized data.
   VRDataQueue(const serialData serializedQueue);
 
   static const serialData noData;
 
-  // We want to be able to use iterators.
+  /// The easiest way to create an iterator to the queue.
   typedef VRDataList::iterator iterator;
+  /// The easiest way to create an iterator to the queue.
   typedef VRDataList::const_iterator const_iterator;
 
+  /// \brief Returns an iterator to the first item in the queue.
   iterator begin() { return _dataMap.begin(); }
+  /// \brief Returns an iterator to the first item in the queue.
   const_iterator begin() const { return _dataMap.begin(); }
+  /// \brief Returns an iterator past the last item in the queue.
   iterator end() { return _dataMap.end(); }
+  /// \brief Returns an iterator past the last item in the queue.
   const_iterator end() const { return _dataMap.end(); }
 
   /// Process a chunk of XML into queue items and add them to the
   /// existing queue.
   void addSerializedQueue(const serialData serializedQueue);
 
-  /// Add another queue's data to this one.
+  /// \brief Add another queue's data to this one.
+  ///
+  /// The data queue is heterogeneous and contains both serialized
+  /// data and pointers to VRDataIndex objects.  The queues that are
+  /// added to each other can be mixed, too.
   void addQueue(const VRDataQueue newQueue);
 
   /// \brief A boolean to determine whether there is anything in the queue.
@@ -207,25 +220,28 @@ public:
   /// A more traditional test.
   bool empty() const { return !(bool)_dataMap.size(); }
 
-  /// \brief Returns the event at the head of the queue, but does not remove
-  /// it.
+  /// \brief Returns the event at the head of the queue.
+  ///
+  /// Does not remove the item.
   VRDataIndex getFirst() const;
 
   /// \brief Return the first item in the queue with its timestamp.
   VRDataListItem getFirstItem() const { return *_dataMap.begin(); };
 
-  /// Removes the object at the front of the queue.
+  /// \brief Removes the object at the front of the queue.
+  ///
+  /// Does not return the value.  Use getFirst() for that.
   void pop();
 
-  /// Removes all the objects in the queue.
+  /// \brief Removes all the objects in the queue.
   void clear();
 
-  /// Makes a timestamp from system facilities.
+  /// \brief Makes a timestamp from system facilities.
   long long makeTimeStamp();
 
-  /// Adds an event to the queue.
+  /// \brief Adds an event to the queue.
   void push(const VRDataIndex event);
-  /// Adds a serialized event to the queue.
+  /// \brief Adds a serialized event to the queue.
   void push(const serialData eventString);
 
   /// \brief Adds an event to the queue with a given time stamp.
@@ -238,17 +254,21 @@ public:
   /// \brief Adds a serialized event to the queue with a given time stamp.
   ///
   /// Use this method if you want to generate your own time stamp, perhaps
-  // for debugging.  Objects in the queue will be sorted by the time stamp,
-  // and will be popped off the stack in time stamp order.
+  /// for debugging.  Objects in the queue will be sorted by the time stamp,
+  /// and will be popped off the stack in time stamp order.
   void push(const long long timeStamp, const serialData eventString);
 
-  // Serialize the whole queue into a piece of XML.
+  /// \brief Serialize the whole queue into a piece of XML.
   serialData serialize();
 
-  // A debug-friendly output function.
+  /// \brief An output function.
+  ///
+  /// Mostly for debugging, prints a list of the queue elements.  An asterisk
+  /// indicates whether the element is stored as serial data or as a pointer to
+  /// a VRDataIndex object.
   std::string printQueue() const;
 
-  // How big is the queue?
+  /// \brief How big is the queue?
   int size() { return _dataMap.size(); };
 
 };

--- a/src/config/VRDataQueue.h
+++ b/src/config/VRDataQueue.h
@@ -62,6 +62,11 @@ public:
     _dataIndex(index), _serialData("") {};
   VRDataQueueItem(std::string str) : _dataIndex(NULL), _serialData(str) {};
 
+  /// \brief Flag to say whether the entry is serialized or not.
+  ///
+  /// This is mostly for debugging, perhaps just for the curious.
+  bool isSerialized() const { return (_dataIndex == NULL); };
+
   std::string serialize() const {
     if (_dataIndex) {
       return _dataIndex->serialize();
@@ -161,6 +166,11 @@ private:
   typedef std::map<VRTimeStamp,VRDataQueueItem> VRDataList;
   VRDataList _dataMap;
 
+  friend std::ostream & operator<<(std::ostream &os, const VRDataQueue& dq) {
+    return os << dq.printQueue();
+  }
+
+
 public:
   VRDataQueue() {};
   VRDataQueue(const serialData serializedQueue);
@@ -234,7 +244,7 @@ public:
   serialData serialize();
 
   // A debug-friendly output function.
-  std::string printQueue();
+  std::string printQueue() const;
 
   // How big is the queue?
   int size() { return _dataMap.size(); };

--- a/src/config/VRDataQueue.h
+++ b/src/config/VRDataQueue.h
@@ -87,54 +87,10 @@ public:
 };
 
 
-
-// template
-// <
-//     class Type,
-//     class UnqualifiedType = std::remove_cv<Type>
-// >
-// class ForwardIterator
-//   : public std::iterator<std::forward_iterator_tag,
-//                          UnqualifiedType,
-//                          std::ptrdiff_t,
-//                          Type*,
-//                          Type&> {
-//   VRDataPairnode<UnqualifiedType>* itr;
-
-//   explicit ForwardIterator(node<UnqualifiedType>* nd) : itr(nd) {}
-
-// public:
-//   /// Default constructor.
-//   ///
-//   /// Empty argument gives end().
-//   ForwardIterator() : itr(nullptr) {}
-
-//   void swap(ForwardIterator& other) noexcept {
-//     using std::swap;
-//     swap(itr, other.iter);
-//   }
-
-//   /// Pre-increment operator.
-//   ForwardIterator& operator++ () {
-//     assert(itr != nullptr && "Out-of-bounds iterator increment!");
-//     itr = itr->next;
-//     return *this;
-//   }
-
-//   /// Post-increment operator.
-//   ForwardIterator operator++ (int) {
-//     assert(itr != nullptr && "Out-of-bounds iterator increment!");
-//     ForwardIterator tmp(*this);
-//     itr = itr->next;
-//     return tmp;
-//   }
-
-
-
 /// \brief A queue of MinVR events.
 ///
 ///
-/// This object maintains a queue (FIFO) of serialized VRDatum objects,
+/// This object maintains a queue (FIFO) of serialized "event" objects,
 /// ordered by a timestamp.  Events, which are just small VRDataIndex
 /// objects, are pushed onto the queue, examined, and popped off.  You can
 /// serialize a queue, preparing it to be sent across a network, and you can
@@ -151,6 +107,12 @@ public:
 /// Use this queue for sending data to some other process, or receiving
 /// it.  The transmission format is the same XML format as in the
 /// VRDataIndex description.
+///
+/// Note that the queue supports both serialized data and raw data.  If you
+/// add serialized data to the queue, it will remain serialized until you
+/// ask for it with getFirst().  If you add raw data (in the form of a
+/// VRDataIndex object (a/k/a VRRawEvent), it will remain raw data, unless
+/// the queue is serialized for transmission over the network.
 ///
 class VRDataQueue {
 public:

--- a/src/config/VRDataQueue.h
+++ b/src/config/VRDataQueue.h
@@ -2,6 +2,16 @@
 #ifndef MINVR_DATAQUEUE_H
 #define MINVR_DATAQUEUE_H
 
+//
+// Copyright Brown University, 2017.  This software is released under the
+// following license: http://opensource.org/licenses/
+// Source code originally developed at the Brown University Center for
+// Computation and Visualization (ccv.brown.edu).
+//
+// Code author(s):
+//   Tom Sgouros
+//
+
 #include <string>
 #include <map>
 #include <sstream>
@@ -9,79 +19,147 @@
 #include <iomanip>
 
 #ifdef WIN32
-	#include <winsock2.h> // must be included before windows.h because we are also using it in net
-	#include <windows.h>  
-	#include <ctime>  
+// winsock2 must be included before windows.h because we are also using it in net
+	#include <winsock2.h>
+	#include <windows.h>
+	#include <ctime>
 #else
 	#include <sys/time.h>
 #endif
 #include <stdio.h>
 #include <stdexcept>
 
+#include <config/VRDataIndex.h>
+
 namespace MinVR {
 
-// This object maintains a queue (FIFO) of serialized VRDatum objects.
-// Serialization turns them into strings, so this is basically just a
-// queue of strings.  See the VRDataIndex object for more about these
-// objects and their types as part of a system of named data values.
-// Over here, we don't care so much about names, as about times of
-// creation, and quick assembly and disassembly into serialized data.
-//
-// Use this queue for sending data to some other process, or receiving
-// it.  The transmission format is the same XML format as in the
-// VRDataIndex description.
-//
-// Tom Sgouros 10/16/2015
-//
-//
+/// \brief Contains an item on the VRDataQueue.
+///
+/// This class contains an item representing an event on a VRDataQueue.  It
+/// might be a serialized collection of variables representing a part or an
+/// entire VRDataIndex, or it might be a pointer to an entire VRDataIndex,
+/// not serialized.  The class exists merely to allow the ambiguity.  The
+/// point is to support networked queue operations (where data must be
+/// serialized) as well as queue operations within a single process running on
+/// a specific machine where performance demands mean we should not serialize
+/// the data all the time.
+class VRDataQueueItem {
+private:
+  VRDataIndex* _dataIndex;
+  std::string _serialData;
+
+public:
+  VRDataQueueItem() : _dataIndex(NULL), _serialData("") {};
+  VRDataQueueItem(VRDataIndex* index) :
+    _dataIndex(index), _serialData("") {};
+  VRDataQueueItem(std::string str) : _dataIndex(NULL), _serialData(str) {};
+
+  std::string serialize() const {
+    if (_dataIndex) {
+      return _dataIndex->serialize();
+    } else {
+      return _serialData;
+    }
+  }
+
+  VRDataIndex getValue() const {
+    if (_dataIndex) {
+      return *_dataIndex;
+    } else {
+      return VRDataIndex(_serialData);
+    }
+  }
+};
+
+/// \brief A queue of MinVR events.
+///
+///
+/// This object maintains a queue (FIFO) of serialized VRDatum objects,
+/// ordered by a timestamp.  Events, which are just small VRDataIndex
+/// objects, are pushed onto the queue, examined, and popped off.  You can
+/// serialize a queue, preparing it to be sent across a network, and you can
+/// also add the contents of one queue to another and have all the events
+/// come out in the right time order.
+///
+/// The system is meant to support network operations -- where the entire
+/// queue is sent across a network and therefore must be serialized -- as
+/// well as threaded operation, where no network and no serialization are
+/// necessary.  Thus the queue is a map between timestamps and objects that
+/// can contain either a std::string of serialized data or a pointer to a
+/// VRDataIndex object.
+///
+/// Use this queue for sending data to some other process, or receiving
+/// it.  The transmission format is the same XML format as in the
+/// VRDataIndex description.
+///
 class VRDataQueue {
 public:
     typedef std::string serialData;
-  
+
 private:
 
   typedef std::pair<long long,int> VRTimeStamp;
-  typedef std::map<VRTimeStamp,serialData> VRDataList;
+  typedef std::pair<VRTimeStamp,VRDataQueueItem> VRDataListItem;
+  typedef std::map<VRTimeStamp,VRDataQueueItem> VRDataList;
   VRDataList dataMap;
-  
+
 public:
   VRDataQueue() {};
   VRDataQueue(const serialData serializedQueue);
 
   static const serialData noData;
 
-  // Process a chunk of XML into queue items and add them to the
-  // existing queue.  The constructor calls this method.
+  /// Process a chunk of XML into queue items and add them to the
+  /// existing queue.
   void addSerializedQueue(const serialData serializedQueue);
-  
-  bool notEmpty() { return (bool)dataMap.size(); }
 
-  // Returns the object at the head of the queue, but does not remove
-  // it from the queue.
-  serialData getSerializedObject();
-  // Removes the object at the front of the queue.
+  /// Add another queue's data to this one.
+  void addQueue(const VRDataQueue newQueue);
+
+  /// \brief A boolean to determine whether there is anything in the queue.
+  bool notEmpty() const { return (bool)dataMap.size(); }
+
+  /// \brief Returns the event at the head of the queue, but does not remove
+  /// it.
+  VRDataIndex getFirst() const;
+
+  /// \brief Return the first item in the queue with its timestamp.
+  VRDataListItem getFirstItem() const { return *dataMap.begin(); };
+
+  /// Removes the object at the front of the queue.
   void pop();
 
-  // Removes all the objects in the queue.
+  /// Removes all the objects in the queue.
   void clear();
-  
-  // Takes a serialized bit of data and pushes it onto the end of the
-  // queue.
-  void push(const serialData serializedData);
-  // You can use this one if you want to generate your own time stamp.
-  // Objects in the queue will be sorted by the time stamp, and will
-  // be popped off the stack in time stamp order.
-  void push(const long long timeStamp, const serialData serializedData);
 
-  // Serialize the whole queue into a piece of XML.  
+  /// Adds an event to the queue.
+  void push(const VRDataIndex event);
+  /// Adds a serialized event to the queue.
+  void push(const serialData eventString);
+
+  /// \brief Adds an event to the queue with a given time stamp.
+  ///
+  /// Use this method if you want to generate your own time stamp, perhaps
+  /// for debugging.  Objects in the queue will be sorted by the time stamp,
+  /// and will be popped off the stack in time stamp order.
+  void push(const long long timeStamp, const VRDataQueueItem item);
+
+  /// \brief Adds a serialized event to the queue with a given time stamp.
+  ///
+  /// Use this method if you want to generate your own time stamp, perhaps
+  // for debugging.  Objects in the queue will be sorted by the time stamp,
+  // and will be popped off the stack in time stamp order.
+  void push(const long long timeStamp, const serialData eventString);
+
+  // Serialize the whole queue into a piece of XML.
   serialData serialize();
 
   // A debug-friendly output function.
-  std::string printQueue(); 
+  std::string printQueue();
 
   // How big is the queue?
   int size() { return dataMap.size(); };
-  
+
 };
 
 } // end namespace MinVR

--- a/src/input/VRFakeTrackerDevice.cpp
+++ b/src/input/VRFakeTrackerDevice.cpp
@@ -4,8 +4,8 @@
 
 namespace MinVR {
 
-    
-    
+
+
 VRFakeTrackerDevice::VRFakeTrackerDevice(const std::string &trackerName,
                                          const std::string &toggleOnOffEventName,
                                          float xyScale,
@@ -22,7 +22,7 @@ VRFakeTrackerDevice::VRFakeTrackerDevice(const std::string &trackerName,
     _state = VRFakeTrackerDevice::XYTranslating;
     _z = 0.0;
 }
-    
+
 
 
 VRFakeTrackerDevice::~VRFakeTrackerDevice()
@@ -59,14 +59,14 @@ void VRFakeTrackerDevice::onVREvent(const VRDataIndex &eventData)
             if (_tracking) {
                 float deltaX = mousex - _lastMouseX;
                 float deltaY = mousey - _lastMouseY;
-            
+
                 if (_state == VRFakeTrackerDevice::ZTranslating) {
                     _z += _zScale * deltaY;
                 }
                 else if (_state == VRFakeTrackerDevice::Rotating) {
                     _R = VRMatrix4::rotationY(_rScale*deltaX) * VRMatrix4::rotationX(-_rScale*deltaY) * _R;
                 }
-            
+
                 VRVector3 pos = VRVector3(_xyScale * mousex, _xyScale * mousey, _z);
                 VRMatrix4 xform  = VRMatrix4::translation(pos) * _R;
 
@@ -74,40 +74,42 @@ void VRFakeTrackerDevice::onVREvent(const VRDataIndex &eventData)
                 di.addData("Transform", xform);
                 _pendingEvents.push_back(di);
             }
-            
+
             _lastMouseX = mousex;
             _lastMouseY = mousey;
         }
     }
 }
 
-  
-void VRFakeTrackerDevice::appendNewInputEventsSinceLastCall(std::vector<VRDataIndex> *inputEvents)
+
+void VRFakeTrackerDevice::appendNewInputEventsSinceLastCall(VRDataQueue* queue)
 {
-    for (std::vector<VRDataIndex>::iterator evt = _pendingEvents.begin(); evt < _pendingEvents.end(); ++evt) {
-        inputEvents->push_back(*evt);
+    for (std::vector<VRDataIndex>::iterator evt = _pendingEvents.begin();
+         evt < _pendingEvents.end(); ++evt) {
+      queue->push(evt->serialize());
     }
     _pendingEvents.clear();
 }
-  
+
 
 VRInputDevice*
-VRFakeTrackerDevice::create(VRMainInterface *vrMain, VRDataIndex *config, const std::string &nameSpace) {
-    std::string devNameSpace = nameSpace;
-  
-    std::string trackerName = config->getValue("TrackerName", devNameSpace);
-    std::string toggleEvent = config->getValue("ToggleOnOffEvent", devNameSpace);
-    float xyScale = config->getValue("XYTranslationScale", devNameSpace);
-    float zScale = config->getValue("ZTranslationScale", devNameSpace);
-    float rScale = config->getValue("RotationScale", devNameSpace);
-    
-    VRFakeTrackerDevice *dev = new VRFakeTrackerDevice(trackerName, toggleEvent, xyScale, zScale, rScale);
-    vrMain->addEventHandler(dev);
+VRFakeTrackerDevice::create(VRMainInterface *vrMain, VRDataIndex *config,
+                            const std::string &nameSpace) {
+  std::string devNameSpace = nameSpace;
 
-    return dev;
+  std::string trackerName = config->getValue("TrackerName", devNameSpace);
+  std::string toggleEvent = config->getValue("ToggleOnOffEvent", devNameSpace);
+  float xyScale = config->getValue("XYTranslationScale", devNameSpace);
+  float zScale = config->getValue("ZTranslationScale", devNameSpace);
+  float rScale = config->getValue("RotationScale", devNameSpace);
+
+  VRFakeTrackerDevice *dev = new VRFakeTrackerDevice(trackerName, toggleEvent, xyScale, zScale, rScale);
+  vrMain->addEventHandler(dev);
+
+  return dev;
 }
 
-  
+
 } // end namespace
 
 

--- a/src/input/VRFakeTrackerDevice.h
+++ b/src/input/VRFakeTrackerDevice.h
@@ -1,14 +1,14 @@
 /**
  This file is part of the MinVR Open Source Project, which is developed and
  maintained collaboratively by the University of Minnesota and Brown University.
- 
+
  Copyright (c) 2016 Regents of the University of Minnesota and Brown University.
  This software is distributed under the BSD-3 Clause license, which can be found
  at: MinVR/LICENSE.txt.
- 
+
  Original Author(s) of this File:
 	Dan Keefe, 2017, University of Minnesota
-	
+
  Author(s) of Significant Updates/Modifications to the File:
 	...
  */
@@ -34,44 +34,44 @@ namespace MinVR {
   */
 class VRFakeTrackerDevice : public VRInputDevice, public VREventHandler {
 public:
-    
+
     VRFakeTrackerDevice(const std::string &trackerName,
                         const std::string &toggleOnOffEventName,
                         float xyScale,
                         float zScale,
                         float rotScale);
-    
+
     virtual ~VRFakeTrackerDevice();
-    
+
     void onVREvent(const VRDataIndex &eventData);
 
-    void appendNewInputEventsSinceLastCall(std::vector<VRDataIndex> *inputEvents);
+    void appendNewInputEventsSinceLastCall(VRDataQueue* queue);
 
     static VRInputDevice* create(VRMainInterface *vrMain, VRDataIndex *config, const std::string &nameSpace);
-    
+
 private:
-    
+
     std::string _eventName;
     std::string _toggleEvent;
     float _xyScale;
     float _zScale;
     float _rScale;
-    
+
     enum TrackingState {
         XYTranslating,
         ZTranslating,
         Rotating,
     };
-    
+
     TrackingState _state;
     bool _tracking;
     float _z;
     VRMatrix4 _R;
     float _lastMouseX, _lastMouseY;
-    
+
     std::vector<VRDataIndex> _pendingEvents;
 };
-    
+
 } // end namespace
 
 #endif

--- a/src/input/VRInputDevice.h
+++ b/src/input/VRInputDevice.h
@@ -3,6 +3,7 @@
 
 #include <vector>
 #include <config/VRDataIndex.h>
+#include <config/VRDataQueue.h>
 
 /** Abstract base class for Input Devices.  Input devices are polled once per frame by
 	VRMain and should return any new events generated since the last call.
@@ -13,11 +14,11 @@ namespace MinVR {
 class VRInputDevice {
 public:
 	virtual ~VRInputDevice() {}
-    virtual void appendNewInputEventsSinceLastCall(std::vector<VRDataIndex> *inputEvents) = 0;
+  virtual void appendNewInputEventsSinceLastCall(VRDataQueue* queue) = 0;
 
 	static std::string getAttributeName(){ return "inputdeviceType"; };
 };
 
 } // ending namespace MinVR
- 
+
 #endif

--- a/src/main/VRMain.cpp
+++ b/src/main/VRMain.cpp
@@ -694,67 +694,52 @@ void VRMain::initializeInternal(int argc, char **argv) {
 }
 
 void
-VRMain::synchronizeAndProcessEvents()
-{
+VRMain::synchronizeAndProcessEvents() {
+
 	if (!_initialized) {
 		throw std::runtime_error("VRMain not initialized.");
 	}
 
   VRDataQueue eventQueue;
 
-    // Add a standard "FrameStart" event at the beginning of each frame
-    VRDataIndex frameStartEvent;
-    frameStartEvent.setName("FrameStart");
-    frameStartEvent.addData("ElapsedSeconds", (float)VRSystem::getTime());
-    frameStartEvent.addData("EventType", "AnalogChange");
-    frameStartEvent.linkNode("ElapsedSeconds", "DefaultData");
-    eventQueue.push(frameStartEvent.serialize());
+  // Add a standard "FrameStart" event at the beginning of each frame
+  VRDataIndex frameStartEvent;
+  frameStartEvent.setName("FrameStart");
+  frameStartEvent.addData("ElapsedSeconds", (float)VRSystem::getTime());
+  frameStartEvent.addData("EventType", "AnalogChange");
+  frameStartEvent.linkNode("ElapsedSeconds", "DefaultData");
+  eventQueue.push(frameStartEvent.serialize());
 
-    for (int f = 0; f < _inputDevices.size(); f++) {
-        _inputDevices[f]->appendNewInputEventsSinceLastCall(&eventQueue);
-    }
+  for (int f = 0; f < _inputDevices.size(); f++) {
+    _inputDevices[f]->appendNewInputEventsSinceLastCall(&eventQueue);
+  }
 
 	// SYNCHRONIZATION POINT #1: When this function returns, we know
 	// that all MinVR nodes have the same list of input events generated
 	// since the last call to synchronizeAndProcessEvents(..).  So,
 	// every node will process the same set of input events this frame.
-    VRDataQueue::serialData eventData;
-    if (_net != NULL) {
-      _net->syncEventDataAcrossAllNodes(eventQueue.serialize());
-    }
-    else if (eventQueue.notEmpty()) {
-      // TODO: There is no need to serialize here if we are not a network node
-      eventData = eventQueue.serialize();
-    }
+  if (_net != NULL) {
+    eventQueue = _net->syncEventDataAcrossAllNodes(eventQueue);
+  }
 
-    VRDataQueue *events = new VRDataQueue(eventData);
-    while (events->notEmpty()) {
-      // Unpack the next item from the queue.
-
-
-      // Invoke the user's callback on the new event
-      for (int f = 0; f < _eventHandlers.size(); f++) {
-        _eventHandlers[f]->onVREvent(VRDataIndex(events->getSerializedObject()));
-      }
-
-      // Get the next item from the queue.
-      events->pop();
+  while (eventQueue.notEmpty()) {
+    // Unpack the next item from the queue and invoke the user's
+    // callback on it.
+    for (int f = 0; f < _eventHandlers.size(); f++) {
+      _eventHandlers[f]->onVREvent(eventQueue.getFirst());
     }
 
-    delete events;
+    // Remove the item from the queue.
+    eventQueue.pop();
+  }
 
-
-    // for (std::vector<VRDataIndex>::iterator evt = events.begin(); evt < events.end(); ++evt) {
-    //     // Invoke the user's callback on the new event
-    //     for (int f = 0; f < _eventHandlers.size(); f++) {
-    //         _eventHandlers[f]->onVREvent(*evt);
-    //     }
-    // }
+  // At this point the eventQueue should be empty with all its events
+  // distributed to the user callback.  Our job here is done and we can
+  // safely get out.
 }
 
-void
-VRMain::renderOnAllDisplays()
-{
+void VRMain::renderOnAllDisplays() {
+
   if (!_initialized) throw std::runtime_error("VRMain not initialized.");
 
 	VRDataIndex renderState;

--- a/src/main/VRMain.cpp
+++ b/src/main/VRMain.cpp
@@ -703,8 +703,7 @@ VRMain::synchronizeAndProcessEvents() {
   VRDataQueue eventQueue;
 
   // Add a standard "FrameStart" event at the beginning of each frame
-  VRDataIndex frameStartEvent;
-  frameStartEvent.setName("FrameStart");
+  VRDataIndex frameStartEvent("FrameStart");
   frameStartEvent.addData("ElapsedSeconds", (float)VRSystem::getTime());
   frameStartEvent.addData("EventType", "AnalogChange");
   frameStartEvent.linkNode("ElapsedSeconds", "DefaultData");

--- a/src/main/VRMain.cpp
+++ b/src/main/VRMain.cpp
@@ -700,7 +700,7 @@ VRMain::synchronizeAndProcessEvents()
 		throw std::runtime_error("VRMain not initialized.");
 	}
 
-    std::vector<VRDataIndex> events;
+  VRDataQueue eventQueue;
 
     // Add a standard "FrameStart" event at the beginning of each frame
     VRDataIndex frameStartEvent;
@@ -708,27 +708,48 @@ VRMain::synchronizeAndProcessEvents()
     frameStartEvent.addData("ElapsedSeconds", (float)VRSystem::getTime());
     frameStartEvent.addData("EventType", "AnalogChange");
     frameStartEvent.linkNode("ElapsedSeconds", "DefaultData");
-    events.push_back(frameStartEvent);
-    
+    eventQueue.push(frameStartEvent.serialize());
+
     for (int f = 0; f < _inputDevices.size(); f++) {
-        _inputDevices[f]->appendNewInputEventsSinceLastCall(&events);
+        _inputDevices[f]->appendNewInputEventsSinceLastCall(&eventQueue);
     }
 
 	// SYNCHRONIZATION POINT #1: When this function returns, we know
 	// that all MinVR nodes have the same list of input events generated
 	// since the last call to synchronizeAndProcessEvents(..).  So,
 	// every node will process the same set of input events this frame.
-	if (_net != NULL) {
-        _net->syncEventDataAcrossAllNodes(&events);
-	}
-
-    
-    for (std::vector<VRDataIndex>::iterator evt = events.begin(); evt < events.end(); ++evt) {
-        // Invoke the user's callback on the new event
-        for (int f = 0; f < _eventHandlers.size(); f++) {
-            _eventHandlers[f]->onVREvent(*evt);
-        }
+    VRDataQueue::serialData eventData;
+    if (_net != NULL) {
+      _net->syncEventDataAcrossAllNodes(eventQueue.serialize());
     }
+    else if (eventQueue.notEmpty()) {
+      // TODO: There is no need to serialize here if we are not a network node
+      eventData = eventQueue.serialize();
+    }
+
+    VRDataQueue *events = new VRDataQueue(eventData);
+    while (events->notEmpty()) {
+      // Unpack the next item from the queue.
+
+
+      // Invoke the user's callback on the new event
+      for (int f = 0; f < _eventHandlers.size(); f++) {
+        _eventHandlers[f]->onVREvent(VRDataIndex(events->getSerializedObject()));
+      }
+
+      // Get the next item from the queue.
+      events->pop();
+    }
+
+    delete events;
+
+
+    // for (std::vector<VRDataIndex>::iterator evt = events.begin(); evt < events.end(); ++evt) {
+    //     // Invoke the user's callback on the new event
+    //     for (int f = 0; f < _eventHandlers.size(); f++) {
+    //         _eventHandlers[f]->onVREvent(*evt);
+    //     }
+    // }
 }
 
 void

--- a/src/net/VRNetClient.cpp
+++ b/src/net/VRNetClient.cpp
@@ -147,25 +147,15 @@ VRNetClient::~VRNetClient()
 }
 
 
-VRDataQueue::serialData
-VRNetClient::syncEventDataAcrossAllNodes(VRDataQueue::serialData eventData)
-{
-
-  // TODO TOM:  Serialize events into eventData here...
-
-
+VRDataQueue VRNetClient::syncEventDataAcrossAllNodes(VRDataQueue eventQueue) {
 
   // 1. send inputEvents to server
-  sendEventData(_socketFD, eventData);
+  sendEventData(_socketFD, eventQueue.serialize());
 
   // 2. receive all events from the server
   VRDataQueue::serialData allEventData = waitForAndReceiveEventData(_socketFD);
 
-  return allEventData;
-  // TODO TOM: Deserialize allEventData into events array here...
-  // events->clear();
-  // events->push_back(....);
-
+  return VRDataQueue(allEventData);
 }
 
 void

--- a/src/net/VRNetClient.cpp
+++ b/src/net/VRNetClient.cpp
@@ -48,14 +48,14 @@ VRNetClient::VRNetClient(const std::string &serverIP, const std::string &serverP
 	    std::cerr << "socket() failed with error: " << WSAGetLastError() << std::endl;
         continue;
       }
-    
+
       if (connect(sockfd, p->ai_addr, (int)p->ai_addrlen) == SOCKET_ERROR) {
         closesocket(sockfd);
         sockfd = INVALID_SOCKET;
 	    std::cerr << "connect() to server socket failed" << std::endl;
         continue;
       }
-    
+
       break;
     }
   }
@@ -65,7 +65,7 @@ VRNetClient::VRNetClient(const std::string &serverIP, const std::string &serverP
     //return 2;
     exit(2);
   }
-  
+
   //inet_ntop(p->ai_family, get_in_addr2((struct sockaddr *)p->ai_addr), s, sizeof s);
   //printf("client: connecting to %s\n", s);
   printf("client: connected\n");
@@ -82,11 +82,11 @@ VRNetClient::VRNetClient(const std::string &serverIP, const std::string &serverP
 #else  // BSD sockets implementation
 
 
-  int sockfd;  
+  int sockfd;
   struct addrinfo hints, *servinfo, *p;
   int rv;
   char s[INET6_ADDRSTRLEN];
-  
+
   memset(&hints, 0, sizeof hints);
   hints.ai_family = AF_UNSPEC;
   hints.ai_socktype = SOCK_STREAM;
@@ -96,7 +96,7 @@ VRNetClient::VRNetClient(const std::string &serverIP, const std::string &serverP
     //return 1;
     exit(1);
   }
-  
+
   //This is a temporary fix to ensure the client can connect and that the connection is not refused
   while(p == NULL){
     // loop through all the results and connect to the first we can
@@ -105,13 +105,13 @@ VRNetClient::VRNetClient(const std::string &serverIP, const std::string &serverP
         perror("client: socket");
         continue;
       }
-    
+
       if (connect(sockfd, p->ai_addr, p->ai_addrlen) == -1) {
         close(sockfd);
         perror("client: connect");
         continue;
       }
-    
+
       break;
     }
   }
@@ -120,7 +120,7 @@ VRNetClient::VRNetClient(const std::string &serverIP, const std::string &serverP
     //return 2;
     exit(2);
   }
-  
+
   inet_ntop(p->ai_family, get_in_addr2((struct sockaddr *)p->ai_addr), s, sizeof s);
   printf("client: connected to %s\n", s);
 
@@ -138,7 +138,7 @@ VRNetClient::VRNetClient(const std::string &serverIP, const std::string &serverP
 
 VRNetClient::~VRNetClient()
 {
-#ifdef WIN32 
+#ifdef WIN32
   closesocket(_socketFD);
   WSACleanup();
 #else
@@ -147,29 +147,29 @@ VRNetClient::~VRNetClient()
 }
 
 
-void
-VRNetClient::syncEventDataAcrossAllNodes(std::vector<VRDataIndex> *events)
+VRDataQueue::serialData
+VRNetClient::syncEventDataAcrossAllNodes(VRDataQueue::serialData eventData)
 {
 
   // TODO TOM:  Serialize events into eventData here...
-  VRDataQueue::serialData eventData;
-    
-    
+
+
+
   // 1. send inputEvents to server
   sendEventData(_socketFD, eventData);
 
   // 2. receive all events from the server
   VRDataQueue::serialData allEventData = waitForAndReceiveEventData(_socketFD);
 
-
+  return allEventData;
   // TODO TOM: Deserialize allEventData into events array here...
   // events->clear();
   // events->push_back(....);
-    
+
 }
 
-void 
-VRNetClient::syncSwapBuffersAcrossAllNodes() 
+void
+VRNetClient::syncSwapBuffersAcrossAllNodes()
 {
   // 1. send a swap_buffers_request message to the server
   sendSwapBuffersRequest(_socketFD);
@@ -178,4 +178,4 @@ VRNetClient::syncSwapBuffersAcrossAllNodes()
   waitForAndReceiveSwapBuffersNow(_socketFD);
 }
 
-} // end namespace MinVR  
+} // end namespace MinVR

--- a/src/net/VRNetClient.cpp
+++ b/src/net/VRNetClient.cpp
@@ -15,7 +15,8 @@ void *get_in_addr2(struct sockaddr *sa) {
 
 VRNetClient::VRNetClient(const std::string &serverIP, const std::string &serverPort)
 {
-	printf("client: connecting...\n");
+  std::cerr << "client: connecting..." << std::endl;
+
 #ifdef WIN32  // WinSock implementation
 
   WSADATA wsaData;
@@ -81,18 +82,18 @@ VRNetClient::VRNetClient(const std::string &serverIP, const std::string &serverP
 
 #else  // BSD sockets implementation
 
-
   int sockfd;
   struct addrinfo hints, *servinfo, *p;
   int rv;
   char s[INET6_ADDRSTRLEN];
+  char problemString[50];
 
   memset(&hints, 0, sizeof hints);
   hints.ai_family = AF_UNSPEC;
   hints.ai_socktype = SOCK_STREAM;
 
   if ((rv = getaddrinfo(serverIP.c_str(), serverPort.c_str(), &hints, &servinfo)) != 0) {
-    fprintf(stderr, "getaddrinfo: %s\n", gai_strerror(rv));
+    std::cerr << "getaddrinfo: " << std::string(gai_strerror(rv)) << std::endl;
     //return 1;
     exit(1);
   }
@@ -108,7 +109,9 @@ VRNetClient::VRNetClient(const std::string &serverIP, const std::string &serverP
 
       if (connect(sockfd, p->ai_addr, p->ai_addrlen) == -1) {
         close(sockfd);
-        perror("client: connect");
+        sprintf(problemString,
+                "client (pid=%d) connection issue, will retry", getpid());
+        perror(problemString);
         continue;
       }
 
@@ -116,13 +119,13 @@ VRNetClient::VRNetClient(const std::string &serverIP, const std::string &serverP
     }
   }
   if (p == NULL) {
-    fprintf(stderr, "client: failed to connect\n");
+    std::cerr << "client: failed to connect" << std::endl;
     //return 2;
     exit(2);
   }
 
   inet_ntop(p->ai_family, get_in_addr2((struct sockaddr *)p->ai_addr), s, sizeof s);
-  printf("client: connected to %s\n", s);
+  std::cerr << "client: connected to " << s << std::endl;
 
   freeaddrinfo(servinfo); // all done with this structure
 

--- a/src/net/VRNetClient.h
+++ b/src/net/VRNetClient.h
@@ -16,7 +16,8 @@ class VRNetClient : public VRNetInterface {
   VRNetClient(const std::string &serverIP, const std::string &serverPort);
   ~VRNetClient();
 
-  void syncEventDataAcrossAllNodes(std::vector<VRDataIndex> *events);
+  VRDataQueue::serialData
+  syncEventDataAcrossAllNodes(VRDataQueue::serialData eventData);
 
   void syncSwapBuffersAcrossAllNodes();
 
@@ -27,7 +28,7 @@ class VRNetClient : public VRNetInterface {
 };
 
 
-} // end namespace MinVR  
+} // end namespace MinVR
 
 
 #endif

--- a/src/net/VRNetClient.h
+++ b/src/net/VRNetClient.h
@@ -16,8 +16,7 @@ class VRNetClient : public VRNetInterface {
   VRNetClient(const std::string &serverIP, const std::string &serverPort);
   ~VRNetClient();
 
-  VRDataQueue::serialData
-  syncEventDataAcrossAllNodes(VRDataQueue::serialData eventData);
+  VRDataQueue syncEventDataAcrossAllNodes(VRDataQueue eventQueue);
 
   void syncSwapBuffersAcrossAllNodes();
 

--- a/src/net/VRNetInterface.h
+++ b/src/net/VRNetInterface.h
@@ -32,8 +32,7 @@ namespace MinVR {
 
 class VRNetInterface {
 public:
-  virtual VRDataQueue::serialData
-    syncEventDataAcrossAllNodes(VRDataQueue::serialData eventData) = 0;
+  virtual VRDataQueue syncEventDataAcrossAllNodes(VRDataQueue eventQueue) = 0;
 	virtual void syncSwapBuffersAcrossAllNodes() = 0;
 
 	virtual ~VRNetInterface() {};

--- a/src/net/VRNetInterface.h
+++ b/src/net/VRNetInterface.h
@@ -32,7 +32,8 @@ namespace MinVR {
 
 class VRNetInterface {
 public:
-    virtual void syncEventDataAcrossAllNodes(std::vector<VRDataIndex> *events) = 0;
+  virtual VRDataQueue::serialData
+    syncEventDataAcrossAllNodes(VRDataQueue::serialData eventData) = 0;
 	virtual void syncSwapBuffersAcrossAllNodes() = 0;
 
 	virtual ~VRNetInterface() {};

--- a/src/net/VRNetServer.h
+++ b/src/net/VRNetServer.h
@@ -22,9 +22,7 @@ class VRNetServer : public VRNetInterface {
   VRNetServer(const std::string &listenPort, int numExpectedClients);
   ~VRNetServer();
 
-  VRDataQueue::serialData
-    syncEventDataAcrossAllNodes(VRDataQueue::serialData eventData);
-  VRDataQueue::serialData syncEventDataAcrossAllNodes();
+  VRDataQueue syncEventDataAcrossAllNodes(VRDataQueue eventQueue);
 
   void syncSwapBuffersAcrossAllNodes();
 

--- a/src/net/VRNetServer.h
+++ b/src/net/VRNetServer.h
@@ -15,14 +15,15 @@
 #include <config/VRDataIndex.h>
 
 namespace MinVR {
-  
+
 class VRNetServer : public VRNetInterface {
  public:
 
   VRNetServer(const std::string &listenPort, int numExpectedClients);
   ~VRNetServer();
 
-  void syncEventDataAcrossAllNodes(std::vector<VRDataIndex> *events);
+  VRDataQueue::serialData
+    syncEventDataAcrossAllNodes(VRDataQueue::serialData eventData);
   VRDataQueue::serialData syncEventDataAcrossAllNodes();
 
   void syncSwapBuffersAcrossAllNodes();

--- a/tests-batch/CMakeLists.txt
+++ b/tests-batch/CMakeLists.txt
@@ -1,5 +1,6 @@
 add_subdirectory(config)
 add_subdirectory(main)
+add_subdirectory(net)
 #add_subdirectory(eventdata)
 #add_subdirectory(eventhandler)
 #add_subdirectory(plugin)

--- a/tests-batch/config/CMakeLists.txt
+++ b/tests-batch/config/CMakeLists.txt
@@ -9,7 +9,7 @@ set (dataindextests datum index queue)
 # test program.  See, e.g., datumtest.cpp
 set (datum_parts 1 2 3 4 5 6 7 8 9 10)
 set (index_parts 1 2 3 4 5 6 7 8 9 10 11 12 13 14)
-set (queue_parts 1 2 3 4)
+set (queue_parts 1 2 3 4 5)
 
 # For tests where a list of parts has not been defined we add a default of 1:
 foreach(dataindextest ${dataindextests})

--- a/tests-batch/config/CMakeLists.txt
+++ b/tests-batch/config/CMakeLists.txt
@@ -9,7 +9,7 @@ set (dataindextests datum index queue)
 # test program.  See, e.g., datumtest.cpp
 set (datum_parts 1 2 3 4 5 6 7 8 9 10)
 set (index_parts 1 2 3 4 5 6 7 8 9 10 11 12 13 14)
-set (queue_parts 1 2 3)
+set (queue_parts 1 2 3 4)
 
 # For tests where a list of parts has not been defined we add a default of 1:
 foreach(dataindextest ${dataindextests})

--- a/tests-batch/config/CMakeLists.txt
+++ b/tests-batch/config/CMakeLists.txt
@@ -9,7 +9,7 @@ set (dataindextests datum index queue)
 # test program.  See, e.g., datumtest.cpp
 set (datum_parts 1 2 3 4 5 6 7 8 9 10)
 set (index_parts 1 2 3 4 5 6 7 8 9 10 11 12 13 14)
-set (queue_parts 1 2 3 4 5)
+set (queue_parts 1 2 3 4 5 6)
 
 # For tests where a list of parts has not been defined we add a default of 1:
 foreach(dataindextest ${dataindextests})

--- a/tests-batch/config/queuetest.cpp
+++ b/tests-batch/config/queuetest.cpp
@@ -5,6 +5,7 @@ int TestQueueArray();
 int TestQueueUnpack();
 int TestQueueMultipleTimeStamps();
 int TestQueueIterator();
+int TestAddQueue();
 
 int queuetest(int argc, char* argv[]) {
 
@@ -38,10 +39,12 @@ int queuetest(int argc, char* argv[]) {
     output = TestQueueIterator();
     break;
 
+  case 5:
+    output = TestAddQueue();
+    break;
+
     // Need test of notEmpty and empty()
     //
-    // And test of iterator.
-
 
     // Add case statements to handle other values.
   default:
@@ -139,6 +142,48 @@ std::string removeTimeStamps(const std::string inString) {
   return outString;
 }
 
+int TestAddQueue() {
+
+  int out = 0;
+
+  MinVR::VRDataQueue q1, q2;
+
+  char ename[10], fname[10];
+  std::vector<MinVR::VRRawEvent> e(10), f(10);
+
+  for (int i = 0; i < 10; i++) {
+    sprintf(ename, "ENAME%d", i);
+    e[i] = MinVR::VRRawEvent(ename);
+    e[i].addData("testInt", i);
+    q1.push(e[i]);
+
+    sprintf(fname, "FNAME%d", i);
+    f[i] = MinVR::VRRawEvent(fname);
+    f[i].addData("testInt", 10-i);
+    q2.push(f[i]);
+  }
+
+  // Now we have two queues, each of which has ten entries that were
+  // added in alternating fashion.  If the time stamps and everthing
+  // work out right, then when the two queues are added, the entries
+  // from each should appear alternating, too.
+
+  // Add the queues.
+  q1.addQueue(q2);
+
+  // This is how we expect the entries to appear.
+  int expectedOrder[20] = {0,10,1,9,2,8,3,7,4,6,5,5,6,4,7,3,8,2,9,1};
+
+  int j = 0;
+  while (q1.notEmpty()) {
+
+    std::cout << "Entry:" << q1.getFirst() << std::endl;
+    if (expectedOrder[j++] != (int)q1.getFirst().getValue("testInt")) out++;
+    q1.pop();
+  }
+
+  return out;
+}
 
 int TestQueueIterator() {
 
@@ -153,8 +198,8 @@ int TestQueueIterator() {
     sprintf(name, "NAME%d", i);
     n[i] = MinVR::VRDataIndex(name);
 
-    // To make sure the order comes out the way we want it, we are inverting
-    // the order of the timestamps.
+    // To test the ordering features as well, we are spoofing the time
+    // stamps, and inverting their order.
     n[i].addData("indexValue", i);
     q.push(10 - i, MinVR::VRDataQueueItem(&n[i]));
   }

--- a/tests-batch/config/queuetest.cpp
+++ b/tests-batch/config/queuetest.cpp
@@ -270,9 +270,9 @@ int TestQueueIterator() {
   int j = 0;
   int expectedValue[11] = {9, 8, 7, 6, 5, 100, 4, 3, 2, 1, 0};
   for (MinVR::VRDataQueue::iterator it = q.begin(); it != q.end(); it++) {
-    std::cout << "Entry:" << it->second.getValue() << std::endl;
+    std::cout << "Entry:" << it->second.getData() << std::endl;
     // If the indexValue in the queue item is the same as j, all is well.
-    if (expectedValue[j++] != (int)it->second.getValue().getValue("indexValue"))
+    if (expectedValue[j++] != (int)it->second.getData().getValue("indexValue"))
       out++;
   }
 

--- a/tests-batch/config/queuetest.cpp
+++ b/tests-batch/config/queuetest.cpp
@@ -173,7 +173,7 @@ int TestQueueUnpack() {
   MinVR::VRDataIndex *n = setupQIndex();
   MinVR::VRDataQueue *q = new MinVR::VRDataQueue;
 
-  std::vector<int>e;
+  std::vector<int> e;
 
   for (int i = 0; i < 100; i++) {
     e.push_back(i);
@@ -183,25 +183,29 @@ int TestQueueUnpack() {
   n->addData("/george/atestarray", e);
 
   // Get the serialized version of an index object.
-  testString = n->serialize("/george");
+  testString = n->serialize("/george/atestarray");
 
   // Put that object into the queue.
   q->push(n->serialize("/george"));
 
-  MinVR::VRDataIndex* index = new MinVR::VRDataIndex;
-
   // Unpack the serialized object.
-  index->addSerializedValue( q->getSerializedObject(), "/" );
+  MinVR::VRDataIndex index = q->getFirst();
 
   // Unpack it into a different index.
-  std::string output = index->serialize("/george");
+  std::string output = index.serialize("atestarray");
+
+  // std::cout << "testString:" << testString << std::endl;
+  // std::cout << "output    :" << output << std::endl;
 
   // Does it match?
   int out = testString.compare(output);
 
+  // The "george" name becomes the name of the index itself.
+  std::string testName = "george";
+  out += testName.compare(index.getName());
+
   delete n;
   delete q;
-  delete index;
 
   return out;
 }
@@ -247,16 +251,16 @@ int TestQueueMultipleTimeStamps() {
 
   // Make sure the values with the same timestamps come out in a
   // consistent order.
-  out += q->getSerializedObject().substr(1, 8).compare("vladimir");
+  out += q->getFirst().serialize().substr(1, 8).compare("vladimir");
   q->pop();
 
-  out += q->getSerializedObject().substr(1, 8).compare("estragon");
+  out += q->getFirst().serialize().substr(1, 8).compare("estragon");
   q->pop();
 
-  out += q->getSerializedObject().substr(1, 5).compare("pozzo");
+  out += q->getFirst().serialize().substr(1, 5).compare("pozzo");
   q->pop();
 
-  out += q->getSerializedObject().substr(1, 5).compare("lucky");
+  out += q->getFirst().serialize().substr(1, 5).compare("lucky");
   q->pop();
 
   return out;

--- a/tests-batch/config/queuetest.cpp
+++ b/tests-batch/config/queuetest.cpp
@@ -4,6 +4,7 @@
 int TestQueueArray();
 int TestQueueUnpack();
 int TestQueueMultipleTimeStamps();
+int TestQueueIterator();
 
 int queuetest(int argc, char* argv[]) {
 
@@ -32,6 +33,15 @@ int queuetest(int argc, char* argv[]) {
   case 3:
     output = TestQueueMultipleTimeStamps();
     break;
+
+  case 4:
+    output = TestQueueIterator();
+    break;
+
+    // Need test of notEmpty and empty()
+    //
+    // And test of iterator.
+
 
     // Add case statements to handle other values.
   default:
@@ -129,6 +139,44 @@ std::string removeTimeStamps(const std::string inString) {
   return outString;
 }
 
+
+int TestQueueIterator() {
+
+  int out = 0;
+
+  std::vector<MinVR::VRDataIndex> n(10);
+  MinVR::VRDataQueue q;
+
+  for (int i = 0; i < 10; i++) {
+
+    char name[10];
+    sprintf(name, "NAME%d", i);
+    n[i] = MinVR::VRDataIndex(name);
+
+    // To make sure the order comes out the way we want it, we are inverting
+    // the order of the timestamps.
+    n[i].addData("indexValue", i);
+    q.push(10 - i, MinVR::VRDataQueueItem(&n[i]));
+  }
+
+  // Now add one more, with a redundant time value.
+  MinVR::VRDataIndex nf = MinVR::VRDataIndex("NAMElast");
+  nf.addData("indexValue", 100);
+  q.push(5, MinVR::VRDataQueueItem(&nf));
+
+  // Now we have a queue with 11 little data index objects in it.
+
+  int j = 0;
+  int expectedValue[11] = {9, 8, 7, 6, 5, 100, 4, 3, 2, 1, 0};
+  for (MinVR::VRDataQueue::iterator it = q.begin(); it != q.end(); it++) {
+    std::cout << "Entry:" << it->second.getValue() << std::endl;
+    // If the indexValue in the queue item is the same as j, all is well.
+    if (expectedValue[j++] != (int)it->second.getValue().getValue("indexValue"))
+      out++;
+  }
+
+  return out;
+}
 
 
 int TestQueueArray() {

--- a/tests-batch/main/utilitytest.cpp
+++ b/tests-batch/main/utilitytest.cpp
@@ -136,7 +136,7 @@ int testSearchPath() {
   // semantic issues.
 
 
-  std::cout << "libRoot:" << libRoot<< "libName:" << libName << std::endl;
+  std::cout << "libRoot:" << libRoot<< "->libName:" << libName << std::endl;
 
   // Look for a plugin, using the root name.
   MinVR::VRSearchPlugin spp;
@@ -145,7 +145,18 @@ int testSearchPath() {
   std::cout << "spp:" << spp.findFile(libRoot) << std::endl;
 
   // Did we find it?
-  out += spp.findFile(libRoot).compare("testSearch/test2/test4/Henry/lib/libHenryd.dylib");
+  std::string compareString = "testSearch/test2/test4/Henry/lib/lib" + libRoot +
+#ifdef MinVR_DEBUG
+    "d" +
+#endif
+#ifdef __APPLE__
+    ".dylib"
+#else
+    ".so"
+#endif
+    ;
+
+  out += spp.findFile(libRoot).compare(compareString);
 
   MinVR::VRSearchConfig spc;
   spc.digestPathString(sp.getPath());

--- a/tests-batch/net/CMakeLists.txt
+++ b/tests-batch/net/CMakeLists.txt
@@ -1,0 +1,38 @@
+# Create some test programs from the source files in this directory.
+
+## Run these tests with 'make test' or 'ctest -VV' if you want to see
+## the output.  You can also do 'ctest --memcheck' that runs the tests
+## with some memory checking enabled.
+
+set (networktests network)
+# The numbers here correspond to 'case' statements in the respective
+# test program.  See, e.g., datumtest.cpp
+set (network_parts 1 2 3)
+
+# Fix this to match the config version after the networktest binary works ok.
+set(networktestsrc networktest.cpp)
+
+create_test_sourcelist(srclist RunSomeNetworkTests.cpp ${networktestsrc})
+add_executable(test-network ${srclist})
+target_link_libraries(test-network MinVR)
+
+# Helper program related to the use of fork() and execl().
+add_executable(launchSwapClient launchSwapClient.cpp)
+target_link_libraries(launchSwapClient MinVR)
+
+# When it's compiled you can run the test-network executable and
+# specify a particular test and subtest:
+#./test-network queuetest 1
+#All that's left is to tell CMake to generate the test cases:
+
+set($ENV{MVRHOME} ${CMAKE_SOURCE_DIR})
+
+foreach(networktest ${networktests})
+  foreach(part ${${networktest}_parts})
+    add_test(NAME test_${networktest}_${part}
+      COMMAND ${CMAKE_BINARY_DIR}/bin/test-network ${networktest}test ${part}
+      WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}/tests-batch/config)
+    set_tests_properties(test_${networktest}_${part} PROPERTIES
+      FAIL_REGULAR_EXPRESSION "ERROR;FAIL;Test failed")
+  endforeach()
+endforeach()

--- a/tests-batch/net/CMakeLists.txt
+++ b/tests-batch/net/CMakeLists.txt
@@ -3,6 +3,10 @@
 ## Run these tests with 'make test' or 'ctest -VV' if you want to see
 ## the output.  You can also do 'ctest --memcheck' that runs the tests
 ## with some memory checking enabled.
+##
+## If you want to run only the network tests, try a command like this:
+## 'ctest -R test_network_2 -VV'.  The -R is a regex match, so you can use
+## -R network_2 or something smaller, too.
 
 set (networktests network)
 # The numbers here correspond to 'case' statements in the respective
@@ -16,9 +20,17 @@ create_test_sourcelist(srclist RunSomeNetworkTests.cpp ${networktestsrc})
 add_executable(test-network ${srclist})
 target_link_libraries(test-network MinVR)
 
-# Helper program related to the use of fork() and execl().
+# Helper programs for the test.  We use these to start up clients with
+# whom to test communications.  Their need is related to the use of
+# fork() and execl().  Apparently it's unwise to do anything with a
+# fork substantially more complicated than issuing an execl.  So the
+# tests fork, but the forks just start up these client programs.
 add_executable(launchSwapClient launchSwapClient.cpp)
 target_link_libraries(launchSwapClient MinVR)
+
+add_executable(launchEventClient launchEventClient.cpp)
+target_link_libraries(launchEventClient MinVR)
+
 
 # When it's compiled you can run the test-network executable and
 # specify a particular test and subtest:

--- a/tests-batch/net/launchEventClient.cpp
+++ b/tests-batch/net/launchEventClient.cpp
@@ -1,0 +1,47 @@
+#include "net/VRNetClient.h"
+#include "config/VRDataIndex.h"
+
+// Program to launch one VRNetClient that connects to server.  Created
+// client executes syncEventDataAcrossAllNodes.  The program is
+// intended to be executed by a forked child process in the network
+// tests.  We do this in a separate program because of limitations of
+// fork() that are made less limiting when it simply starts up a new
+// binary using execl().
+int main(int argc, char* argv[]) {
+
+  int clientNumber;
+  sscanf(argv[1], "%d", &clientNumber);
+
+  int numberOfSends;
+  sscanf(argv[2], "%d", &numberOfSends);
+
+  MinVR::VRNetClient client = MinVR::VRNetClient("localhost", "3490");
+
+  // Get the client number from the argv list and the process ID.
+  std::stringstream clientIDstring;
+  clientIDstring << "client " << std::string(argv[1]) << ", pid = " << getpid();
+
+  // Make the event request.
+	std::cout << "launchEventClient: sync event data request from "
+            << clientIDstring.str() << std::endl;
+
+  for (int i = 0; i < numberOfSends; i++) {
+    std::cout << clientIDstring.str() << " listening... ("
+              << i << ")" << std::endl;
+
+    MinVR::VRDataQueue queue;
+    MinVR::VRRawEvent e = MinVR::VRRawEvent("anotherTest");
+    e.addData("client", clientNumber);
+    queue.push(e);
+    std::cout << "*******" << e << std::endl;
+    queue = client.syncEventDataAcrossAllNodes(queue);
+
+    std::cout << "queue name: " << queue.getFirst().getName() << std::endl;
+
+    std::cout << "launchEventClient: event " << i+1 << " received by "
+              << clientIDstring.str() << ": " << queue.getFirst() << std::endl;
+  }
+
+  std::cout << "Process " << getpid() << " exiting normally." << std::endl;
+	exit(0);
+}

--- a/tests-batch/net/launchSwapClient.cpp
+++ b/tests-batch/net/launchSwapClient.cpp
@@ -1,0 +1,32 @@
+#include "net/VRNetClient.h"
+
+// Program to launch one VRNetClient that connects to server.  Created
+// client executes syncSwapBuffersAcrossAllNodes.  The program is
+// intended to be executed by a forked child process in the network
+// tests.  We do this in a separate program because of limitations of
+// execl() that are made less limiting when it simply starts up a new
+// binary.
+int main(int argc, char* argv[]) {
+
+  MinVR::VRNetClient client = MinVR::VRNetClient("localhost", "3490");
+
+  // Engineer a small sleep sometimes.
+  srand(time(NULL));
+  sleep(3 + (random() % 4));
+
+  // Get the client number from the argv list and the process ID.
+  std::stringstream clientIDstring;
+  clientIDstring << "client " << std::string(argv[1]) << ", pid = " << getpid();
+
+  // Make the swap buffers request.
+	std::cout << "launchSwapClient: sync swap buffers request from "
+            << clientIDstring.str() << std::endl;
+
+  for (int i = 0; i < 10; i++) {
+    client.syncSwapBuffersAcrossAllNodes();
+    std::cout << "launchSwapClient: swap request " << i << " received, "
+            << clientIDstring.str() << std::endl;
+  }
+
+	exit(0);
+}

--- a/tests-batch/net/launchSwapClient.cpp
+++ b/tests-batch/net/launchSwapClient.cpp
@@ -10,10 +10,6 @@ int main(int argc, char* argv[]) {
 
   MinVR::VRNetClient client = MinVR::VRNetClient("localhost", "3490");
 
-  // Engineer a small sleep sometimes.
-  srand(time(NULL));
-  sleep(3 + (random() % 4));
-
   // Get the client number from the argv list and the process ID.
   std::stringstream clientIDstring;
   clientIDstring << "client " << std::string(argv[1]) << ", pid = " << getpid();

--- a/tests-batch/net/networktest.cpp
+++ b/tests-batch/net/networktest.cpp
@@ -1,0 +1,120 @@
+#include "net/VRNetClient.h"
+#include "net/VRNetServer.h"
+
+#include "config/VRDataIndex.h"
+#include "config/VRDataQueue.h"
+
+int TestSwapBufferSignal();
+int TestTwo();
+int TestThree();
+
+int networktest(int argc, char* argv[]) {
+//int main(int argc, char* argv[]) {
+
+  int defaultchoice = 1;
+
+  int choice = defaultchoice;
+
+  if (argc > 1) {
+    if(sscanf(argv[1], "%d", &choice) != 1) {
+      printf("Couldn't parse that input as a number\n");
+      return -1;
+    }
+  }
+
+  int output;
+
+  switch(choice) {
+  case 1:
+    output = TestSwapBufferSignal();
+    break;
+
+  case 2:
+    output = TestTwo();
+    break;
+
+  case 3:
+    output = TestThree();
+    break;
+
+    // Add case statements to handle other values.
+  default:
+    std::cout << "Test #" << choice << " does not exist!\n";
+    output = -1;
+  }
+
+  return output;
+}
+
+int TestSwapBufferSignal() {
+
+  int numberOfClients = 10;
+  int ret;
+
+  std::vector<pid_t> clientPIDs(numberOfClients);
+
+  // Fork N clients to connect to the server.
+  std::string launchSwapClient = std::string(BINARYPATH) + "/launchSwapClient";
+  std::cout << "Using: " << launchSwapClient << std::endl;
+
+  std::stringstream clientNumber;
+  for (int i = 0; i < numberOfClients; i++) {
+    clientPIDs[i] = fork();
+
+    if (clientPIDs[i] != 0) {
+      // This is still on the main fork, and the PID returned belongs
+      // to the process that was forked.
+      std::cout << "client " << i+1
+                << " forked, pid = " << clientPIDs[i] << std::endl;
+
+    } else {
+      // The forked client returns 0 from the fork() call.
+
+      clientNumber << i+1;
+      ret = execl(launchSwapClient.c_str(),
+                  launchSwapClient.c_str(),
+                  clientNumber.str().c_str(), (char*)NULL);
+
+      // Shouldn't get here, unless the execl() fails.
+      if (ret < 0) {
+        std::cerr << "execl number " << i << " failed: " << errno << std::endl;
+        return 1;
+      }
+    }
+  }
+
+  std::cout << "All clients forked, open for business now." << std::endl;
+
+	MinVR::VRNetServer server = MinVR::VRNetServer("3490", numberOfClients);
+
+  for (int i = 0; i < 10; i++) {
+    server.syncSwapBuffersAcrossAllNodes();
+    std::cout << "All swaps for request " << i << " made by server." << std::endl;
+  }
+
+  // Waits for all the child processes to finish running
+  for (int i = 0; i < numberOfClients; ++i) {
+    int status;
+
+    while (-1 == waitpid(clientPIDs[i], &status, WNOHANG));
+    std::cout << "waited for " << clientPIDs[i] << std::endl;
+    if (!WIFEXITED(status) || WEXITSTATUS(status) != 0) {
+      std::cout << "WIFSIGNALED=" << WIFSIGNALED(status) << '\n';
+      std::cout << "WIFSTOPPED=" << WIFSTOPPED(status) << '\n';
+      std::cout << "WTERMSIG=" << WTERMSIG(status) << '\n';
+      std::cout << "WSTOPSIG=" << WSTOPSIG(status) << '\n';
+      if (WIFSIGNALED(status) != 0) {
+        cerr << "Process " << i+1 << " (pid " << clientPIDs[i] << ") failed" << endl;
+        return 1;
+      } else {
+        return 0;
+      }
+    }
+  }
+  std::cout << "CLIENT SUCCESS" << std::endl;
+
+  return 0; }
+
+int TestTwo() { return 0; }
+
+int TestThree() { return 0; }


### PR DESCRIPTION
This pull request remakes the VRDataQueue so that it supports either serialized or non-serialized VRDataIndex entries transparently.  Add either format to the queue, and read them back in either format. I have added a bunch of tests for these new capabilities.

I've also added some tests for networking capabilities, to test whether the queue is really behaving as advertised. They only work on linux and mac, and work by forking a bunch of clients and running swapBuffers and syncEventData with them. Don't know if this is functionality worth exporting to Win.