### PR TITLE
bug fixes and updates to beta in order to get 3DUIExample working with the latest

### DIFF
--- a/config/YURT.minvr
+++ b/config/YURT.minvr
@@ -94,7 +94,7 @@ Btn,B03,B04,B05,B06,B07,B08,B09,B10,B11,B12,B13,B14,B15,B16</EventsToGenerate>
 
   <YURTGraph>
     <RootNode displaynodeType="VRGraphicsWindowNode" windowtoolkitType="VRFreeGLUTWindowToolkit" graphicstoolkitType="VROpenGLGraphicsToolkit">
-      <LookAtNode displaynodeType="VRTrackedLookAtNode">
+      <LookAtNode displaynodeType="VRHeadTrackingNode">
         <StereoNode displaynodeType="VRStereoNode">
           <MyProjectionNode displaynodeType="VRScalableNode">
             <NearClip>0.01</NearClip>

--- a/config/default.minvr
+++ b/config/default.minvr
@@ -1,61 +1,119 @@
+
+<!-- This config works well for a desktop window that is designed to debug VR
+  Apps. It includes fake trackers, one for the head and one for each hand,
+  that are controlled through keyboard and mouse events.  In this way, you can
+  test apps that expect input from 6-DOF trackers in a desktop mode.
+
+  It is rare that programmers will need to change anything in this config
+  file, but the settings that are most likely to change on an app-by-app
+  basis are listed first. -->
+
+
+
 <MinVR>
-  <PluginPath>../../../MinVR2/build/install/plugins</PluginPath>
-	<GLFWPlugin pluginType="MinVR_GLFW"/>
-	<OpenGLPlugin pluginType="MinVR_OpenGL"/>
-
-	  <RGBBits>8</RGBBits>
-	  <AlphaBits>8</AlphaBits>
-	  <DepthBits>24</DepthBits>
-	  <StencilBits>8</StencilBits>
-	  <FullScreen>0</FullScreen>
-	  <Resizable>1</Resizable>
-	  <AllowMaximize>1</AllowMaximize>
-	  <Visible>1</Visible>
-	  <SharedContextGroupID>-1</SharedContextGroupID>
-	  <ContextVersionMajor>3</ContextVersionMajor>
-	  <ContextVersionMinor>3</ContextVersionMinor>
-	  <UseGPUAffinity>1</UseGPUAffinity>
-	  <UseDebugContext>0</UseDebugContext>
-	  <MSAASamples>1</MSAASamples>
-	  <QuadBuffered>0</QuadBuffered>
-
-	  <StereoFormat>Mono</StereoFormat>
 
 
-  <HeadTrackingEvent>Head_Move</HeadTrackingEvent>
+  <!-- GLOBAL SETTINGS (LIKE GLOBAL VARIABLES) -->
 
+
+  <!-- MinVR Plugins to Load - Most Common is to Use OpenGL for the
+     MinVRs GraphicsTookit and GLFW for MinVRs WindowToolkit -->
+  <PluginPath>../../build/plugins</PluginPath>
+
+  <GLFWPlugin pluginType="MinVR_GLFW"/>
+  <GLFWToolkit windowtoolkitType="VRGLFWWindowToolkit"/>
+
+  <OpenGLPlugin pluginType="MinVR_OpenGL"/>
+  <OpenGLToolkit graphicstoolkitType="VROpenGLGraphicsToolkit"/>
+
+
+  <!-- Version Number to Request for the OpenGL Graphcis Rendering Context -->
+  <ContextVersionMajor>3</ContextVersionMajor>
+  <ContextVersionMinor>3</ContextVersionMinor>
+
+
+  <!-- Setup a Desktop-Style Camera -->
   <NearClip>0.001</NearClip>
   <FarClip>500.0</FarClip>
+  <!-- same x,y field of view b/c requesting a square window below -->
+  <FieldOfViewX>60.0</FieldOfViewX>
+  <FieldOfViewY>60.0</FieldOfViewY>
 
-	<VRSetups>
-		<Desktop hostType="VRStandAlone">
-	      <GLFWToolkit windowtoolkitType="VRGLFWWindowToolkit"/>
-	      <OpenGLToolkit graphicstoolkitType="VROpenGLGraphicsToolkit"/>
-	      <RootNode displaynodeType="VRGraphicsWindowNode">
-				<Border>0</Border>
-				<Caption>Desktop</Caption>
-				<GPUAffinity>0</GPUAffinity>
-				<XPos>100</XPos>
-				<YPos>100</YPos>
-				<Width>640</Width>
-				<Height>640</Height>
-				<LookAtNode displaynodeType="VRTrackedLookAtNode">
-					<LookAtUp type="floatarray">0,1,0</LookAtUp>
-					<LookAtEye type="floatarray">0,0,8</LookAtEye>
-					<LookAtCenter type="floatarray">0,0,0</LookAtCenter>
 
-					<StereoNode displaynodeType="VRStereoNode">
-						<EyeSeparation>0.203</EyeSeparation>
-						<ProjectionNode displaynodeType="VROffAxisProjectionNode">
-							 <TopLeft type="floatarray">-2,2,0</TopLeft>
-				             <TopRight type="floatarray">-2,2,0</TopRight>
-				             <BottomLeft type="floatarray">-2,-2,0</BottomLeft>
-				             <BottomRight type="floatarray">2,-2,0</BottomRight>
-				             <DUMMY/>
-			            </ProjectionNode>
-		            </StereoNode>
-                </LookAtNode>
-			</RootNode>
-		</Desktop>
-	</VRSetups>
+  <!-- Stereo Settings -->
+  <QuadBuffered>0</QuadBuffered>
+  <StereoFormat>Mono</StereoFormat>
+  <EyeSeparation>0.203</EyeSeparation>
+
+
+  <!-- Head Tracking with a Default/Initial LookAt -->
+  <HeadTrackingEvent>HeadTracker_Move</HeadTrackingEvent>
+  <LookAtUp type="floatarray">0,1,0</LookAtUp>
+  <LookAtEye type="floatarray">0,0,4</LookAtEye>
+  <LookAtCenter type="floatarray">0,0,0</LookAtCenter>
+
+
+  <!-- Other Graphics Window Settings -->
+  <Caption>MinVR Desktop</Caption>
+  <Border>1</Border>
+  <XPos>100</XPos>
+  <YPos>100</YPos>
+  <Width>1024</Width>
+  <Height>1024</Height>
+  <RGBBits>8</RGBBits>
+  <AlphaBits>8</AlphaBits>
+  <DepthBits>24</DepthBits>
+  <StencilBits>8</StencilBits>
+  <FullScreen>0</FullScreen>
+  <Resizable>1</Resizable>
+  <AllowMaximize>1</AllowMaximize>
+  <Visible>1</Visible>
+  <SharedContextGroupID>-1</SharedContextGroupID>
+  <UseGPUAffinity>1</UseGPUAffinity>
+  <GPUAffinity>0</GPUAffinity>
+  <UseDebugContext>0</UseDebugContext>
+  <MSAASamples>1</MSAASamples>
+
+
+
+
+  <Desktop hostType="VRStandAlone">
+
+    <!-- Input Devices: Three Fake Trackers -->
+
+    <FakeHead inputdeviceType="VRFakeHeadTrackerDevice">
+      <TrackerName>HeadTracker</TrackerName>
+      <ToggleOnOffEvent>Kbd1_Down</ToggleOnOffEvent>
+    </FakeHead>
+
+    <FakeHand1 inputdeviceType="VRFakeHandTrackerDevice">
+      <TrackerName>RHandTracker</TrackerName>
+      <ToggleOnOffEvent>Kbd2_Down</ToggleOnOffEvent>
+      <XYTranslationScale>2.0</XYTranslationScale>
+      <ZTranslationScale>2.0</ZTranslationScale>
+    </FakeHand1>
+
+    <FakeHand2 inputdeviceType="VRFakeHandTrackerDevice">
+      <TrackerName>LHandTracker</TrackerName>
+      <ToggleOnOffEvent>Kbd3_Down</ToggleOnOffEvent>
+      <XYTranslationScale>2.0</XYTranslationScale>
+      <ZTranslationScale>2.0</ZTranslationScale>
+    </FakeHand2>
+
+
+    <!-- Display Devices: Just A Single Graphics Window -->
+
+    <WindowNode displaynodeType="VRGraphicsWindowNode">
+      <TrackingNode displaynodeType="VRHeadTrackingNode">
+        <StereoNode displaynodeType="VRStereoNode">
+          <ProjectionNode displaynodeType="VRProjectionNode">
+            <DUMMY/>
+          </ProjectionNode>
+        </StereoNode>
+      </TrackingNode>
+    </WindowNode>
+
+  </Desktop>
+
+
 </MinVR>

--- a/config/desktop-multithreaded.minvr
+++ b/config/desktop-multithreaded.minvr
@@ -45,7 +45,7 @@
       <ThreadNode displaynodeType="VRThreadGroupNode">
         <Node1 displaynodeType="VRGraphicsWindowNode">
           <Caption>Desktop</Caption>
-          <LookAtNode displaynodeType="VRTrackedLookAtNode">
+          <LookAtNode displaynodeType="VRHeadTrackingNode">
             <StereoNode displaynodeType="VRStereoNode">
               <ProjectionNode displaynodeType="VROffAxisProjectionNode">
                 <TopLeft type="floatarray">-2,2,0</TopLeft>
@@ -59,7 +59,7 @@
         <Node2 displaynodeType="VRGraphicsWindowNode">
           <Caption>Desktop</Caption>
           <XPos>800</XPos>
-          <LookAtNode displaynodeType="VRTrackedLookAtNode">
+          <LookAtNode displaynodeType="VRHeadTrackingNode">
             <StereoNode displaynodeType="VRStereoNode">
               <ProjectionNode displaynodeType="VROffAxisProjectionNode">
                 <TopLeft type="floatarray">-2,2,0</TopLeft>

--- a/config/desktop-oldopengl.minvr
+++ b/config/desktop-oldopengl.minvr
@@ -42,7 +42,7 @@
 				<YPos>100</YPos>
 				<Width>640</Width>
 				<Height>640</Height>
-				<LookAtNode displaynodeType="VRTrackedLookAtNode">
+				<LookAtNode displaynodeType="VRHeadTrackingNode">
 					<StereoNode displaynodeType="VRStereoNode">
 						<ProjectionNode displaynodeType="VROffAxisProjectionNode">
 							 <TopLeft type="floatarray">-2,2,0</TopLeft>

--- a/config/desktop-sidebyside.minvr
+++ b/config/desktop-sidebyside.minvr
@@ -35,7 +35,7 @@
 				<YPos>100</YPos>
 				<Width>1280</Width>
 				<Height>640</Height>
-				<LookAtNode displaynodeType="VRTrackedLookAtNode">
+				<LookAtNode displaynodeType="VRHeadTrackingNode">
 					<LookAtUp type="floatarray">0,1,0</LookAtUp>
 					<LookAtEye type="floatarray">0,0,8</LookAtEye>
 					<LookAtCenter type="floatarray">0,0,0</LookAtCenter>

--- a/config/desktop.minvr
+++ b/config/desktop.minvr
@@ -1,60 +1,119 @@
+
+<!-- This config works well for a desktop window that is designed to debug VR
+  Apps. It includes fake trackers, one for the head and one for each hand,
+  that are controlled through keyboard and mouse events.  In this way, you can
+  test apps that expect input from 6-DOF trackers in a desktop mode.
+
+  It is rare that programmers will need to change anything in this config
+  file, but the settings that are most likely to change on an app-by-app
+  basis are listed first. -->
+
+
+
 <MinVR>
-	<GLFWPlugin pluginType="MinVR_GLFW"/>
-	<OpenGLPlugin pluginType="MinVR_OpenGL"/>
 
-	  <RGBBits>8</RGBBits>
-	  <AlphaBits>8</AlphaBits>
-	  <DepthBits>24</DepthBits>
-	  <StencilBits>8</StencilBits>
-	  <FullScreen>0</FullScreen>
-	  <Resizable>1</Resizable>
-	  <AllowMaximize>1</AllowMaximize>
-	  <Visible>1</Visible>
-	  <SharedContextGroupID>-1</SharedContextGroupID>
-	  <ContextVersionMajor>3</ContextVersionMajor>
-	  <ContextVersionMinor>3</ContextVersionMinor>
-	  <UseGPUAffinity>1</UseGPUAffinity>
-	  <UseDebugContext>0</UseDebugContext>
-	  <MSAASamples>1</MSAASamples>
-	  <QuadBuffered>0</QuadBuffered>
-	  
-	  <StereoFormat>Mono</StereoFormat>
 
-  
-  <HeadTrackingEvent>Head_Move</HeadTrackingEvent>
+  <!-- GLOBAL SETTINGS (LIKE GLOBAL VARIABLES) -->
 
+
+  <!-- MinVR Plugins to Load - Most Common is to Use OpenGL for the
+     MinVRs GraphicsTookit and GLFW for MinVRs WindowToolkit -->
+  <PluginPath>../../build/plugins</PluginPath>
+
+  <GLFWPlugin pluginType="MinVR_GLFW"/>
+  <GLFWToolkit windowtoolkitType="VRGLFWWindowToolkit"/>
+
+  <OpenGLPlugin pluginType="MinVR_OpenGL"/>
+  <OpenGLToolkit graphicstoolkitType="VROpenGLGraphicsToolkit"/>
+
+
+  <!-- Version Number to Request for the OpenGL Graphcis Rendering Context -->
+  <ContextVersionMajor>3</ContextVersionMajor>
+  <ContextVersionMinor>3</ContextVersionMinor>
+
+
+  <!-- Setup a Desktop-Style Camera -->
   <NearClip>0.001</NearClip>
   <FarClip>500.0</FarClip>
-  
-	<VRSetups>
-		<Desktop hostType="VRStandAlone">
-	      <GLFWToolkit windowtoolkitType="VRGLFWWindowToolkit"/>
-	      <OpenGLToolkit graphicstoolkitType="VROpenGLGraphicsToolkit"/>
-	      <RootNode displaynodeType="VRGraphicsWindowNode">
-				<Border>0</Border>
-				<Caption>Desktop</Caption>
-				<GPUAffinity>0</GPUAffinity>	
-				<XPos>100</XPos>
-				<YPos>100</YPos>
-				<Width>640</Width>
-				<Height>640</Height>
-				<LookAtNode displaynodeType="VRTrackedLookAtNode">
-					<LookAtUp type="floatarray">0,1,0</LookAtUp>
-					<LookAtEye type="floatarray">0,0,8</LookAtEye>
-					<LookAtCenter type="floatarray">0,0,0</LookAtCenter>
+  <!-- same x,y field of view b/c requesting a square window below -->
+  <FieldOfViewX>60.0</FieldOfViewX>
+  <FieldOfViewY>60.0</FieldOfViewY>
 
-					<StereoNode displaynodeType="VRStereoNode">
-						<EyeSeparation>0.203</EyeSeparation>
-						<ProjectionNode displaynodeType="VROffAxisProjectionNode">
-							 <TopLeft type="floatarray">-2,2,0</TopLeft>
-				             <TopRight type="floatarray">-2,2,0</TopRight>
-				             <BottomLeft type="floatarray">-2,-2,0</BottomLeft>
-				             <BottomRight type="floatarray">2,-2,0</BottomRight>
-				             <DUMMY/>
-			            </ProjectionNode>
-		            </StereoNode>
-                </LookAtNode>
-			</RootNode>
-		</Desktop>
-	</VRSetups>
+
+  <!-- Stereo Settings -->
+  <QuadBuffered>0</QuadBuffered>
+  <StereoFormat>Mono</StereoFormat>
+  <EyeSeparation>0.203</EyeSeparation>
+
+
+  <!-- Head Tracking with a Default/Initial LookAt -->
+  <HeadTrackingEvent>HeadTracker_Move</HeadTrackingEvent>
+  <LookAtUp type="floatarray">0,1,0</LookAtUp>
+  <LookAtEye type="floatarray">0,0,4</LookAtEye>
+  <LookAtCenter type="floatarray">0,0,0</LookAtCenter>
+
+
+  <!-- Other Graphics Window Settings -->
+  <Caption>MinVR Desktop</Caption>
+  <Border>1</Border>
+  <XPos>100</XPos>
+  <YPos>100</YPos>
+  <Width>1024</Width>
+  <Height>1024</Height>
+  <RGBBits>8</RGBBits>
+  <AlphaBits>8</AlphaBits>
+  <DepthBits>24</DepthBits>
+  <StencilBits>8</StencilBits>
+  <FullScreen>0</FullScreen>
+  <Resizable>1</Resizable>
+  <AllowMaximize>1</AllowMaximize>
+  <Visible>1</Visible>
+  <SharedContextGroupID>-1</SharedContextGroupID>
+  <UseGPUAffinity>1</UseGPUAffinity>
+  <GPUAffinity>0</GPUAffinity>
+  <UseDebugContext>0</UseDebugContext>
+  <MSAASamples>1</MSAASamples>
+
+
+
+
+  <Desktop hostType="VRStandAlone">
+
+    <!-- Input Devices: Three Fake Trackers -->
+
+    <FakeHead inputdeviceType="VRFakeHeadTrackerDevice">
+      <TrackerName>HeadTracker</TrackerName>
+      <ToggleOnOffEvent>Kbd1_Down</ToggleOnOffEvent>
+    </FakeHead>
+
+    <FakeHand1 inputdeviceType="VRFakeHandTrackerDevice">
+      <TrackerName>RHandTracker</TrackerName>
+      <ToggleOnOffEvent>Kbd2_Down</ToggleOnOffEvent>
+      <XYTranslationScale>2.0</XYTranslationScale>
+      <ZTranslationScale>2.0</ZTranslationScale>
+    </FakeHand1>
+
+    <FakeHand2 inputdeviceType="VRFakeHandTrackerDevice">
+      <TrackerName>LHandTracker</TrackerName>
+      <ToggleOnOffEvent>Kbd3_Down</ToggleOnOffEvent>
+      <XYTranslationScale>2.0</XYTranslationScale>
+      <ZTranslationScale>2.0</ZTranslationScale>
+    </FakeHand2>
+
+
+    <!-- Display Devices: Just A Single Graphics Window -->
+
+    <WindowNode displaynodeType="VRGraphicsWindowNode">
+      <TrackingNode displaynodeType="VRHeadTrackingNode">
+        <StereoNode displaynodeType="VRStereoNode">
+          <ProjectionNode displaynodeType="VRProjectionNode">
+            <DUMMY/>
+          </ProjectionNode>
+        </StereoNode>
+      </TrackingNode>
+    </WindowNode>
+
+  </Desktop>
+
+
 </MinVR>

--- a/config/ivlabcave-desktop.minvr
+++ b/config/ivlabcave-desktop.minvr
@@ -82,7 +82,7 @@
     
     <!-- ********************** Display Graph ********************** -->
     <MyDisplayGraph>
-        <HeadTracker displaynodeType="VRTrackedLookAtNode">
+        <HeadTracker displaynodeType="VRHeadTrackingNode">
           <StereoNode displaynodeType="VRStereoNode">
             <ProjectionNode displaynodeType="VROffAxisProjectionNode">
             </ProjectionNode>

--- a/config/ivlabcave.minvr
+++ b/config/ivlabcave.minvr
@@ -128,7 +128,7 @@
     <!-- ********************** Display Graph ********************** -->
     <MyDisplayGraph>
       <WindowNode displaynodeType="VRGraphicsWindowNode">
-        <HeadTracker displaynodeType="VRTrackedLookAtNode">
+        <HeadTracker displaynodeType="VRHeadTrackingNode">
           <StereoNode displaynodeType="VRStereoNode">
             <ProjectionNode displaynodeType="VROffAxisProjectionNode">
 				<DUMMY/>

--- a/config/ivlabcave_multithreaded.minvr
+++ b/config/ivlabcave_multithreaded.minvr
@@ -130,7 +130,7 @@
     
     <!-- ********************** Display Graph ********************** -->
     <MyDisplayGraph>
-        <HeadTracker displaynodeType="VRTrackedLookAtNode">
+        <HeadTracker displaynodeType="VRHeadTrackingNode">
           <StereoNode displaynodeType="VRStereoNode">
             <ProjectionNode displaynodeType="VROffAxisProjectionNode">
 				      <DUMMY/>

--- a/plugins/GLFW/src/VRGLFWInputDevice.cpp
+++ b/plugins/GLFW/src/VRGLFWInputDevice.cpp
@@ -83,7 +83,7 @@ void VRGLFWInputDevice::cursorPositionCallback(GLFWwindow* window, float xpos, f
     pos.push_back(xpos);
     pos.push_back(ypos);
     
-    std::vector<float> npos;
+    std::vector<float> npos = pos;
     int width, height;
     glfwGetWindowSize(window, &width, &height);
     npos[0] /= (float)width;

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -129,10 +129,12 @@ set(vr_display_h
 )
 
 set(vr_input_cpp
+  ${vr_src_dir}/input/VRFakeHandTrackerDevice.cpp
   ${vr_src_dir}/input/VRFakeTrackerDevice.cpp
 )
 
 set(vr_input_h
+  ${vr_src_dir}/input/VRFakeHandTrackerDevice.h
   ${vr_src_dir}/input/VRFakeTrackerDevice.h
   ${vr_src_dir}/input/VRInputDevice.h
 )

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -105,12 +105,12 @@ set(vr_display_cpp
   ${vr_src_dir}/display/VRDisplayNode.cpp
   ${vr_src_dir}/display/VRGraphicsWindowNode.cpp
   ${vr_src_dir}/display/VRGroupNode.cpp
+  ${vr_src_dir}/display/VRHeadTrackingNode.cpp
   ${vr_src_dir}/display/VROffAxisProjectionNode.cpp
   ${vr_src_dir}/display/VRProjectionNode.cpp
   ${vr_src_dir}/display/VRStereoNode.cpp
   ${vr_src_dir}/display/VRViewportNode.cpp
   ${vr_src_dir}/display/VRLookAtNode.cpp
-  ${vr_src_dir}/display/VRTrackedLookAtNode.cpp
 )
 
 set(vr_display_h
@@ -119,22 +119,24 @@ set(vr_display_h
   ${vr_src_dir}/display/VRGraphicsToolkit.h
   ${vr_src_dir}/display/VRGraphicsWindowNode.h
   ${vr_src_dir}/display/VRGroupNode.h
+  ${vr_src_dir}/display/VRHeadTrackingNode.h
   ${vr_src_dir}/display/VROffAxisProjectionNode.h
   ${vr_src_dir}/display/VRProjectionNode.h
   ${vr_src_dir}/display/VRStereoNode.h
   ${vr_src_dir}/display/VRViewportNode.h
   ${vr_src_dir}/display/VRWindowToolkit.h
   ${vr_src_dir}/display/VRLookAtNode.h
-  ${vr_src_dir}/display/VRTrackedLookAtNode.h
 )
 
 set(vr_input_cpp
   ${vr_src_dir}/input/VRFakeHandTrackerDevice.cpp
+  ${vr_src_dir}/input/VRFakeHeadTrackerDevice.cpp
   ${vr_src_dir}/input/VRFakeTrackerDevice.cpp
 )
 
 set(vr_input_h
   ${vr_src_dir}/input/VRFakeHandTrackerDevice.h
+  ${vr_src_dir}/input/VRFakeHeadTrackerDevice.h
   ${vr_src_dir}/input/VRFakeTrackerDevice.h
   ${vr_src_dir}/input/VRInputDevice.h
 )

--- a/src/api/VRGraphicsState.h
+++ b/src/api/VRGraphicsState.h
@@ -109,9 +109,9 @@ private:
     
     const VRDataIndex &_index;
     
-    static float defaultProjMat[16];
-    static float defaultViewMat[16];
-    static float defaultEyePos[3];
+    static float projMat[16];
+    static float viewMat[16];
+    static float eyePos[3];
     static int defaultSharedContextID;
     static int defaultWindowID;
 

--- a/src/api/impl/VRGraphicsState.cpp
+++ b/src/api/impl/VRGraphicsState.cpp
@@ -19,9 +19,9 @@ Author(s) of Significant Updates/Modifications to the File:
 namespace MinVR {
 
     
-float VRGraphicsState::defaultProjMat[16] = {1.0, 0.0, 0.0, 0.0,  0.0, 1.0, 0.0, 0.0,  0.0, 0.0, 1.0, 0.0,  0.0, 0.0, 0.0, 1.0};
-float VRGraphicsState::defaultViewMat[16] = {1.0, 0.0, 0.0, 0.0,  0.0, 1.0, 0.0, 0.0,  0.0, 0.0, 1.0, 0.0,  0.0, 0.0, 0.0, 1.0};
-float VRGraphicsState::defaultEyePos[3] = {0.0, 0.0, 0.0};
+float VRGraphicsState::projMat[16] = {1.0, 0.0, 0.0, 0.0,  0.0, 1.0, 0.0, 0.0,  0.0, 0.0, 1.0, 0.0,  0.0, 0.0, 0.0, 1.0};
+float VRGraphicsState::viewMat[16] = {1.0, 0.0, 0.0, 0.0,  0.0, 1.0, 0.0, 0.0,  0.0, 0.0, 1.0, 0.0,  0.0, 0.0, 0.0, 1.0};
+float VRGraphicsState::eyePos[3] = {0.0, 0.0, 0.0};
 int VRGraphicsState::defaultSharedContextID = 0;
 int VRGraphicsState::defaultWindowID = 0;
     
@@ -41,32 +41,26 @@ const VRDataIndex& VRGraphicsState::index() {
 
 const float * VRGraphicsState::getProjectionMatrix() const {
     if (_index.exists("ProjectionMatrix")) {
-        const std::vector<float> &mat = _index.getValue("ProjectionMatrix");
-        return &mat[0];
+        VRFloatArray mat = _index.getValue("ProjectionMatrix");
+        std::copy(mat.begin(), mat.end(), projMat);
     }
-    else {
-        return defaultProjMat;
-    }
+    return projMat;
 }
 
 const float * VRGraphicsState::getViewMatrix() const {
     if (_index.exists("ViewMatrix")) {
-        const std::vector<float> &mat = _index.getValue("ViewMatrix");
-        return &mat[0];
+        VRFloatArray mat = _index.getValue("ViewMatrix");
+        std::copy(mat.begin(), mat.end(), viewMat);
     }
-    else {
-        return defaultViewMat;
-    }
+    return viewMat;
 }
 
 const float * VRGraphicsState::getCameraPos() const {
     if (_index.exists("EyePosition")) {
-        const std::vector<float> &mat = _index.getValue("EyePosition");
-        return &mat[0];
+        VRFloatArray mat = _index.getValue("EyePosition");
+        std::copy(mat.begin(), mat.end(), eyePos);
     }
-    else {
-        return defaultEyePos;
-    }
+    return eyePos;
 }
 
 bool VRGraphicsState::isInitialRenderCall() const {

--- a/src/display/VRHeadTrackingNode.h
+++ b/src/display/VRHeadTrackingNode.h
@@ -19,15 +19,17 @@
 namespace MinVR {
 
 
-/** 
+/** Adds a HeadMatrix to the RenderState that gets updated repeatedly based
+    upon head tracking events.
  */
-class VRTrackedLookAtNode : public VRDisplayNode, public VREventHandler {
+class VRHeadTrackingNode : public VRDisplayNode, public VREventHandler {
 public:
 
-	VRTrackedLookAtNode(const std::string &name, const std::string &headTrackingEventName, VRMatrix4 initialHeadMatrix);
-	virtual ~VRTrackedLookAtNode();
+	VRHeadTrackingNode(const std::string &name, const std::string &headTrackingEventName, VRMatrix4 initialHeadMatrix);
+    
+	virtual ~VRHeadTrackingNode();
 
-	virtual std::string getType() { return "VRTrackedLookAtNode"; }
+	virtual std::string getType() { return "VRHeadTrackingNode"; }
 
 	virtual void render(VRDataIndex *renderState, VRRenderHandler *renderHandler);
 
@@ -37,7 +39,7 @@ public:
 
 protected:
 
-	VRMatrix4 _lookAtMatrix;
+	VRMatrix4 _headMatrix;
 	std::string _trackingEvent;
 };
 

--- a/src/display/VRLookAtNode.h
+++ b/src/display/VRLookAtNode.h
@@ -18,7 +18,10 @@
 namespace MinVR {
 
 
-/** 
+/** Serves as a stand-in for head tracking on systems that do not support head
+    tracking.  This node can replace a VRHeadTrackingNode by adding a 
+    HeadMatrix entry to the RenderState, where HeadMatrix is defined based upon
+    the LookAt* values specified in a config file.
  */
 class VRLookAtNode : public VRDisplayNode{
 public:
@@ -33,7 +36,7 @@ public:
 	static VRDisplayNode* create(VRMainInterface *vrMain, VRDataIndex *config, const std::string &nameSpace);
 protected:
 
-	VRMatrix4 _lookAtMatrix;
+	VRMatrix4 _headMatrix;
 };
 
 } // end namespace

--- a/src/display/VROffAxisProjectionNode.cpp
+++ b/src/display/VROffAxisProjectionNode.cpp
@@ -7,8 +7,11 @@ namespace MinVR {
 	VROffAxisProjectionNode::VROffAxisProjectionNode(const std::string &name, VRPoint3 topLeft, VRPoint3 botLeft, VRPoint3 topRight, VRPoint3 botRight, float nearClip, float farClip) :
 	VRDisplayNode(name), _topLeft(topLeft), _botLeft(botLeft), _topRight(topRight), _botRight(botRight),  _nearClip(nearClip), _farClip(farClip)
 {
-  _valuesAdded.push_back("/ProjectionMatrix");
-  _valuesAdded.push_back("/ViewMatrix");
+  // in:
+  _valuesAdded.push_back("CameraMatrix");
+  // out:
+  _valuesAdded.push_back("ProjectionMatrix");
+  _valuesAdded.push_back("ViewMatrix");
 }
 
 VROffAxisProjectionNode::~VROffAxisProjectionNode()
@@ -27,13 +30,8 @@ VROffAxisProjectionNode::render(VRDataIndex *renderState, VRRenderHandler *rende
 	VRPoint3 pa = _botLeft;
 	VRPoint3 pb = _botRight;
 	VRPoint3 pc = _topLeft;
-	VRPoint3 pe(0,0,0);
-	if (renderState->exists("/LookAtMatrix")){
-		VRMatrix4 lookAtMatrix = renderState->getValue("/LookAtMatrix");
-		VRMatrix4 head_frame = lookAtMatrix.inverse();
-		pe = VRPoint3(head_frame(0,3), head_frame(1,3), head_frame(2,3));
-	}
-
+    VRMatrix4 cameraMatrix = renderState->getValue("CameraMatrix");
+    VRPoint3 pe = VRPoint3(0,0,0) + cameraMatrix.getColumn(3);
 
 	// Compute an orthonormal basis for the screen
 	VRVector3 vr = (pb - pa).normalize();
@@ -56,7 +54,7 @@ VROffAxisProjectionNode::render(VRDataIndex *renderState, VRRenderHandler *rende
 
 	VRMatrix4 projMat = VRMatrix4::projection(l, r, b, t, _nearClip, _farClip);
 
-	renderState->addData("/ProjectionMatrix", projMat);
+	renderState->addData("ProjectionMatrix", projMat);
 
 	// Rotate the projection to be non-perpendicular
     VRMatrix4 Mrot = VRMatrix4::fromRowMajorElements(vr[0], vr[1], vr[2], 0.0,
@@ -69,7 +67,7 @@ VROffAxisProjectionNode::render(VRDataIndex *renderState, VRRenderHandler *rende
 
 	VRMatrix4 viewMat = Mrot * Mtrans;
 
-	renderState->addData("/ViewMatrix", viewMat);
+	renderState->addData("ViewMatrix", viewMat);
 
 	VRDisplayNode::render(renderState, renderHandler);
 

--- a/src/display/VROffAxisProjectionNode.h
+++ b/src/display/VROffAxisProjectionNode.h
@@ -18,7 +18,10 @@
 namespace MinVR {
 
 
-/** 
+/** Generates projection and view matrices for off-axis projection used in tiled
+    VR displays (e.g., Powerwall, wall of a Cave, 3DTV) that use head tracked
+    perspective rendering.  Takes a CameraMatrix as input in the current
+    RenderState and sets the ProjectionMatrix and ViewMatrix as output.
  */
 class VROffAxisProjectionNode : public VRDisplayNode {
 public:

--- a/src/display/VRProjectionNode.cpp
+++ b/src/display/VRProjectionNode.cpp
@@ -7,9 +7,11 @@ namespace MinVR{
 VRProjectionNode::VRProjectionNode(const std::string &name, float fovX, float fovY, float nearClip, float farClip): 
   VRDisplayNode(name), _fovX(fovX), _fovY(fovY), _nearClip(nearClip), _farClip(farClip)
 {
-  _valuesAdded.push_back("/ProjectionMatrix");
-  _valuesAdded.push_back("/ViewMatrix");
-  _valuesNeeded.push_back("/LookAtMatrix");
+  // in:
+  _valuesAdded.push_back("CameraMatrix");
+  // out:
+  _valuesAdded.push_back("ViewMatrix");
+  _valuesAdded.push_back("ProjectionMatrix");
  
   double degreeToRadian = 3.1415926 / 180;
   float _horizontalClip = tan(fovX * degreeToRadian / 2.0f) * _nearClip;
@@ -29,15 +31,13 @@ void VRProjectionNode::render(VRDataIndex *renderState, VRRenderHandler *renderH
 {
   renderState->pushState();
 
-  renderState->addData("/ProjectionMatrix", _projectionMatrix);
+  renderState->addData("ProjectionMatrix", _projectionMatrix);
 
-  VRMatrix4 viewMat;
-  if (renderState->exists("/LookAtMatrix")){
-    VRMatrix4 lookAtMatrix = renderState->getValue("/LookAtMatrix");
-    lookAtMatrix = lookAtMatrix.inverse();
-    viewMat = lookAtMatrix;
-  }
-  renderState->addData("/ViewMatrix", viewMat);
+  VRMatrix4 cameraMat = renderState->getValue("CameraMatrix");
+    
+  VRMatrix4 viewMat = cameraMat.inverse();
+    
+  renderState->addData("ViewMatrix", viewMat);
 
   VRDisplayNode::render(renderState, renderHandler);
 

--- a/src/display/VRProjectionNode.h
+++ b/src/display/VRProjectionNode.h
@@ -31,7 +31,7 @@ namespace MinVR {
 
 /**
  * Represents a projection node with a near and far clipping plane.
- * Generates View and Projection matrices from the LookAtMatrix
+ * Generates View and Projection matrices from the CameraMatrix
  */
 class VRProjectionNode : public VRDisplayNode {
 public:

--- a/src/display/VRStereoNode.h
+++ b/src/display/VRStereoNode.h
@@ -16,7 +16,11 @@
 namespace MinVR {
 
 
-
+/** Looks for a HeadMatrix in the RenderState and turns it into a CameraMatrix
+    based on the current stereo format and value for EyeSeparation.  Then, calls
+    the rest of the display graph one or two times (if stereo is enabled).  Also 
+    sets an entry in the RenderState for the current Eye being rendered.
+ */
 class VRStereoNode : public VRDisplayNode {
 public:
 	enum VRStereoFormat {
@@ -45,7 +49,7 @@ public:
 
 protected:
 	void renderOneEye(VRDataIndex *renderState, VRRenderHandler *renderHandler, VREyePosition eye);
-	void updateLookAtMatrix(VRDataIndex *renderState, VREyePosition eye);
+	void setCameraMatrix(VRDataIndex *renderState, VREyePosition eye);
 
 	VRGraphicsToolkit *_gfxToolkit;
 	VRStereoFormat _format;

--- a/src/display/VRViewportNode.cpp
+++ b/src/display/VRViewportNode.cpp
@@ -13,10 +13,10 @@ namespace MinVR {
 
 VRViewportNode::VRViewportNode(const std::string &name, VRGraphicsToolkit *gfxToolkit, const VRRect& rect) :
 	VRDisplayNode(name), _rect(rect), _gfxToolkit(gfxToolkit)  {
-  _valuesAdded.push_back("/ViewportX");
-  _valuesAdded.push_back("/ViewportY");
-  _valuesAdded.push_back("/ViewportWidth");
-  _valuesAdded.push_back("/ViewportHeight");
+  _valuesAdded.push_back("ViewportX");
+  _valuesAdded.push_back("ViewportY");
+  _valuesAdded.push_back("ViewportWidth");
+  _valuesAdded.push_back("ViewportHeight");
 }
 
 VRViewportNode::~VRViewportNode() {
@@ -26,10 +26,10 @@ void VRViewportNode::render(VRDataIndex *renderState, VRRenderHandler *renderHan
   renderState->pushState();
 
 	// Is this the kind of state information we expect to pass from one node to the next?
-	renderState->addData("/ViewportX", (int)_rect.getX());
-	renderState->addData("/ViewportY", (int)_rect.getY());
-	renderState->addData("/ViewportWidth", (int)_rect.getWidth());
-	renderState->addData("/ViewportHeight", (int)_rect.getHeight());
+	renderState->addData("ViewportX", (int)_rect.getX());
+	renderState->addData("ViewportY", (int)_rect.getY());
+	renderState->addData("ViewportWidth", (int)_rect.getWidth());
+	renderState->addData("ViewportHeight", (int)_rect.getHeight());
   
 	_gfxToolkit->setSubWindow(_rect);
 

--- a/src/input/VRFakeHandTrackerDevice.cpp
+++ b/src/input/VRFakeHandTrackerDevice.cpp
@@ -1,0 +1,112 @@
+
+#include "VRFakeHandTrackerDevice.h"
+#include <api/VRTrackerEvent.h>
+#include <math/VRMath.h>
+
+namespace MinVR {
+
+    
+    
+VRFakeHandTrackerDevice::VRFakeHandTrackerDevice(const std::string &trackerName,
+                                         const std::string &toggleOnOffEventName,
+                                         float xyScale,
+                                         float zScale,
+                                         float rotScale)
+{
+    _eventName = trackerName + "_Move";
+    _toggleEvent = toggleOnOffEventName;
+    _xyScale = xyScale;
+    _zScale = zScale;
+    _rScale = rotScale;
+
+    _tracking = true;
+    _state = VRFakeHandTrackerDevice::XYTranslating;
+    _z = 0.0;
+}
+    
+
+
+VRFakeHandTrackerDevice::~VRFakeHandTrackerDevice()
+{
+}
+
+
+void VRFakeHandTrackerDevice::onVREvent(const VRDataIndex &event)
+{
+    if (event.getName() == _toggleEvent) {
+        _tracking = !_tracking;
+        if (_tracking) {
+            _state = VRFakeHandTrackerDevice::XYTranslating;
+        }
+    }
+    else if (event.getName() == "KbdZ_Down") {
+        _state = VRFakeHandTrackerDevice::ZTranslating;
+    }
+    else if (event.getName() == "KbdZ_Up") {
+        _state = VRFakeHandTrackerDevice::XYTranslating;
+    }
+    else if (event.getName() == "KbdR_Down") {
+        _state = VRFakeHandTrackerDevice::Rotating;
+    }
+    else if (event.getName() == "KbdR_Up") {
+        _state = VRFakeHandTrackerDevice::XYTranslating;
+    }
+    else if (event.getName() == "Mouse_Move") {
+        VRFloatArray screenPos = event.getValue("NormalizedPosition");
+        if (screenPos.size() >= 2) {
+            float mousex = 2.0*(screenPos[0] - 0.5);
+            float mousey = 2.0*((1.0-screenPos[1]) - 0.5);
+
+            if (_tracking) {
+                float deltaX = mousex - _lastMouseX;
+                float deltaY = mousey - _lastMouseY;
+            
+                if (_state == VRFakeHandTrackerDevice::ZTranslating) {
+                    _z += _zScale * deltaY;
+                }
+                else if (_state == VRFakeHandTrackerDevice::Rotating) {
+                    _R = VRMatrix4::rotationY(_rScale*deltaX) * VRMatrix4::rotationX(-_rScale*deltaY) * _R;
+                }
+            
+                VRVector3 pos = VRVector3(_xyScale * mousex, _xyScale * mousey, _z);
+                VRMatrix4 xform  = VRMatrix4::translation(pos) * _R;
+
+                VRDataIndex di = VRTrackerEvent::createValidDataIndex(_eventName, xform.toVRFloatArray());
+                _pendingEvents.push(di);
+            }
+            
+            _lastMouseX = mousex;
+            _lastMouseY = mousey;
+        }
+    }
+}
+
+    
+void VRFakeHandTrackerDevice::appendNewInputEventsSinceLastCall(VRDataQueue* inputEvents)
+{
+    inputEvents->addQueue(_pendingEvents);
+    _pendingEvents.clear();
+}
+ 
+    
+
+VRInputDevice*
+VRFakeHandTrackerDevice::create(VRMainInterface *vrMain, VRDataIndex *config, const std::string &nameSpace) {
+    std::string devNameSpace = nameSpace;
+  
+    std::string trackerName = config->getValue("TrackerName", devNameSpace);
+    std::string toggleEvent = config->getValue("ToggleOnOffEvent", devNameSpace);
+    float xyScale = config->getValue("XYTranslationScale", devNameSpace);
+    float zScale = config->getValue("ZTranslationScale", devNameSpace);
+    float rScale = config->getValue("RotationScale", devNameSpace);
+    
+    VRFakeHandTrackerDevice *dev = new VRFakeHandTrackerDevice(trackerName, toggleEvent, xyScale, zScale, rScale);
+    vrMain->addEventHandler(dev);
+
+    return dev;
+}
+
+  
+} // end namespace
+
+

--- a/src/input/VRFakeHandTrackerDevice.h
+++ b/src/input/VRFakeHandTrackerDevice.h
@@ -1,0 +1,79 @@
+/**
+ This file is part of the MinVR Open Source Project, which is developed and
+ maintained collaboratively by the University of Minnesota and Brown University.
+ 
+ Copyright (c) 2016 Regents of the University of Minnesota and Brown University.
+ This software is distributed under the BSD-3 Clause license, which can be found
+ at: MinVR/LICENSE.txt.
+ 
+ Original Author(s) of this File:
+	Dan Keefe, 2017, University of Minnesota
+	
+ Author(s) of Significant Updates/Modifications to the File:
+	...
+ */
+
+#ifndef VRFAKEHANDTRACKERDEVICE_H
+#define VRFAKEHANDTRACKERDEVICE_H
+
+#include <config/VRDataIndex.h>
+#include <config/VRDataQueue.h>
+#include <input/VRInputDevice.h>
+#include <main/VRFactory.h>
+#include <math/VRMath.h>
+
+namespace MinVR {
+
+/** A "virtual input device" that converts mouse and keyboard events into
+    6 Degree-of-Freedom tracker events.  This facilitates debugging
+    VR programs on a desktop computer.  Move the mouse to move the tracker
+    in the XY-plane parallel to the scrren.  Hold z to move the tracker
+    in/out of the screen.  Hold 'r' to rotate the tracker with the mouse.
+    The scale factors set in the constructor adjust the sensitivity of the
+    tracker to each of these mouse movements.
+  */
+class VRFakeHandTrackerDevice : public VRInputDevice, public VREventHandler {
+public:
+    
+    VRFakeHandTrackerDevice(const std::string &trackerName,
+                            const std::string &toggleOnOffEventName,
+                            float xyScale,
+                            float zScale,
+                            float rotScale);
+    
+    virtual ~VRFakeHandTrackerDevice();
+    
+    void onVREvent(const VRDataIndex &eventData);
+
+    void appendNewInputEventsSinceLastCall(VRDataQueue *inputEvents);
+
+    static VRInputDevice* create(VRMainInterface *vrMain, VRDataIndex *config, const std::string &nameSpace);
+    
+private:
+    
+    std::string _eventName;
+    std::string _toggleEvent;
+    float _xyScale;
+    float _zScale;
+    float _rScale;
+    
+    enum TrackingState {
+        XYTranslating,
+        ZTranslating,
+        Rotating,
+    };
+    
+    TrackingState _state;
+    bool _tracking;
+    float _z;
+    VRMatrix4 _R;
+    float _lastMouseX, _lastMouseY;
+    
+    VRDataQueue _pendingEvents;
+};
+    
+} // end namespace
+
+#endif
+
+

--- a/src/input/VRFakeHandTrackerDevice.h
+++ b/src/input/VRFakeHandTrackerDevice.h
@@ -26,11 +26,25 @@ namespace MinVR {
 
 /** A "virtual input device" that converts mouse and keyboard events into
     6 Degree-of-Freedom tracker events.  This facilitates debugging
-    VR programs on a desktop computer.  Move the mouse to move the tracker
-    in the XY-plane parallel to the scrren.  Hold z to move the tracker
-    in/out of the screen.  Hold 'r' to rotate the tracker with the mouse.
-    The scale factors set in the constructor adjust the sensitivity of the
-    tracker to each of these mouse movements.
+    VR programs on a desktop computer.  
+ 
+    This UI has a good default mapping for controlling hand-held VR cursors via
+    mouse and keyoard input.  The mouse and keyboard events are trapped and then
+    turned into 6-DOF tracker events so that you can write your program as if it
+    is a VR program listening for tracker move events but control it with your
+    desktop computer.
+ 
+    To move the tracker in a plane parallel to the filmplane, just move the
+    mouse.  Hold the "T" key on the keyboard to enter a translate-in-Z-direction
+    mode, which will map mouse movement to movement perpendicular to the
+    filmplane.  Hold the "R" key to rotate the tracker with the mouse.  Pressing
+    the "2" key on the keyboard, toggles the entire interface on/off.
+ 
+    Finally, note that all of the keys mentioned above are just defaults.  These
+    can be reconfigured in the config file where the VRFakeHeadTrackerDevice is
+    defined.  Scale factors can also be set in the config file to adjust the
+    sensativity of the mouse-to-tracker movements.  The scale factors are 
+    designed so that a default value of 1.0 works well on most machines.
   */
 class VRFakeHandTrackerDevice : public VRInputDevice, public VREventHandler {
 public:
@@ -39,7 +53,9 @@ public:
                             const std::string &toggleOnOffEventName,
                             float xyScale,
                             float zScale,
-                            float rotScale);
+                            float rotScale,
+                            std::vector<std::string> zKeys,
+                            std::vector<std::string> rotKeys);
     
     virtual ~VRFakeHandTrackerDevice();
     
@@ -56,6 +72,9 @@ private:
     float _xyScale;
     float _zScale;
     float _rScale;
+    std::vector<std::string> _zKeys;
+    std::vector<std::string> _rotKeys;
+
     
     enum TrackingState {
         XYTranslating,

--- a/src/input/VRFakeHeadTrackerDevice.cpp
+++ b/src/input/VRFakeHeadTrackerDevice.cpp
@@ -1,0 +1,220 @@
+
+#include "VRFakeHeadTrackerDevice.h"
+#include <api/VRTrackerEvent.h>
+#include <math/VRMath.h>
+
+namespace MinVR {
+
+    
+    
+VRFakeHeadTrackerDevice::VRFakeHeadTrackerDevice(const std::string &trackerName,
+                                         const std::string &toggleOnOffEventName,
+                                         float tScale,
+                                         float rScale,
+                                         VRMatrix4 initialHeadFrame,
+                                         std::vector<std::string> forwardKeys,
+                                         std::vector<std::string> backKeys,
+                                         std::vector<std::string> leftKeys,
+                                         std::vector<std::string> rightKeys,
+                                         std::vector<std::string> mouseRotKeys)
+{
+    _eventName = trackerName + "_Move";
+    _toggleEvent = toggleOnOffEventName;
+    _tScale = tScale;
+    _rScale = rScale;
+    _baseHead = initialHeadFrame;
+    _tracking = true;
+    _yaw = 0.0;
+    _pitch = 0.0;
+    _mouseRotKeys = mouseRotKeys;
+    _mouseRotating = false;
+    
+    for (std::vector<std::string>::iterator it = forwardKeys.begin(); it < forwardKeys.end(); ++it) {
+        _forwardEvents.push_back(*it + "_Down");
+        _forwardEvents.push_back(*it + "_Repeat");
+    }
+    for (std::vector<std::string>::iterator it = backKeys.begin(); it < backKeys.end(); ++it) {
+        _backEvents.push_back(*it + "_Down");
+        _backEvents.push_back(*it + "_Repeat");
+    }
+    for (std::vector<std::string>::iterator it = leftKeys.begin(); it < leftKeys.end(); ++it) {
+        _leftEvents.push_back(*it + "_Down");
+        _leftEvents.push_back(*it + "_Repeat");
+    }
+    for (std::vector<std::string>::iterator it = rightKeys.begin(); it < rightKeys.end(); ++it) {
+        _rightEvents.push_back(*it + "_Down");
+        _rightEvents.push_back(*it + "_Repeat");
+    }
+}
+    
+
+
+VRFakeHeadTrackerDevice::~VRFakeHeadTrackerDevice()
+{
+}
+
+
+    
+bool myEventMatch(std::string eventName, std::vector<std::string> keys, std::string state) {
+    for (std::vector<std::string>::iterator it = keys.begin(); it < keys.end(); ++it) {
+        if (*it + "_" + state == eventName) {
+            return true;
+        }
+    }
+    return false;
+}
+    
+void VRFakeHeadTrackerDevice::onVREvent(const VRDataIndex &event)
+{
+    if (event.getName() == _toggleEvent) {
+        _tracking = !_tracking;
+    }
+    
+    if (_tracking) {
+        bool sendEvent = false;
+        if (std::find(_forwardEvents.begin(), _forwardEvents.end(), event.getName()) != _forwardEvents.end()) {
+            VRMatrix4 M = _baseHead * VRMatrix4::rotationY(-_yaw);
+            VRVector3 dir = M * VRVector3(0,0,-1);
+            dir = dir.normalize();
+            _baseHead = _baseHead * VRMatrix4::translation(0.075 * _tScale * dir);
+            sendEvent = true;
+        }
+        else if (std::find(_backEvents.begin(), _backEvents.end(), event.getName()) != _backEvents.end()) {
+            VRMatrix4 M = _baseHead * VRMatrix4::rotationY(-_yaw);
+            VRVector3 dir = M * VRVector3(0,0,1);
+            dir = dir.normalize();
+            _baseHead = _baseHead * VRMatrix4::translation(0.075 * _tScale * dir);
+            sendEvent = true;
+        }
+        else if (std::find(_leftEvents.begin(), _leftEvents.end(), event.getName()) != _leftEvents.end()) {
+            _baseHead = _baseHead *  VRMatrix4::rotationY(0.025 * _rScale);
+            sendEvent = true;
+        }
+        else if (std::find(_rightEvents.begin(), _rightEvents.end(), event.getName()) != _rightEvents.end()) {
+            _baseHead = _baseHead * VRMatrix4::rotationY(-0.025 * _rScale);
+            sendEvent = true;
+        }
+        else if (myEventMatch(event.getName(), _mouseRotKeys, "Down")) {
+            _mouseRotating = true;
+        }
+        else if (myEventMatch(event.getName(), _mouseRotKeys, "Up")) {
+            _mouseRotating = false;
+        }
+        else if (event.getName() == "Mouse_Move") {
+            VRFloatArray screenPos = event.getValue("NormalizedPosition");
+            if (screenPos.size() >= 2) {
+                float mousex = 2.0*(screenPos[0] - 0.5);
+                float mousey = 2.0*((1.0-screenPos[1]) - 0.5);
+                
+                if (_mouseRotating) {
+                    float deltaX = mousex - _lastMouseX;
+                    float deltaY = mousey - _lastMouseY;
+                    
+                    _yaw += deltaX;
+                    _pitch += deltaY;
+                                        
+                    _addedRot = VRMatrix4::rotationY(-_yaw) * VRMatrix4::rotationX(_pitch);
+                    sendEvent = true;
+                }
+                
+                _lastMouseX = mousex;
+                _lastMouseY = mousey;
+            }
+        }
+        
+        if (sendEvent) {
+            VRMatrix4 M = _baseHead * _addedRot;
+            VRDataIndex di = VRTrackerEvent::createValidDataIndex(_eventName, M.toVRFloatArray());
+            _pendingEvents.push(di);
+        }
+    }
+}
+
+    
+void VRFakeHeadTrackerDevice::appendNewInputEventsSinceLastCall(VRDataQueue* inputEvents)
+{
+    inputEvents->addQueue(_pendingEvents);
+    _pendingEvents.clear();
+}
+ 
+    
+
+VRInputDevice*
+VRFakeHeadTrackerDevice::create(VRMainInterface *vrMain, VRDataIndex *config, const std::string &nameSpace) {
+    std::string devNameSpace = nameSpace;
+  
+    std::string trackerName = config->getValue("TrackerName", devNameSpace);
+    std::string toggleEvent = config->getValueWithDefault("ToggleOnOffEvent", std::string("Kbd1_Down"), devNameSpace);
+    float tScale = config->getValueWithDefault("TranslationScale", 1.0, devNameSpace);
+    float rScale = config->getValueWithDefault("RotationScale", 1.0, devNameSpace);
+    
+    VRMatrix4 headMatrix = VRMatrix4::translation(VRVector3(0,0,4));
+    if (config->exists("HeadMatrix", devNameSpace)){
+        headMatrix = config->getValue("HeadMatrix", devNameSpace);
+    }
+    else if (config->exists("LookAtUp", devNameSpace) && config->exists("LookAtEye", devNameSpace) && config->exists("LookAtCenter", devNameSpace))
+    {
+        VRVector3 up = config->getValue("LookAtUp", devNameSpace);
+        VRVector3 eye = config->getValue("LookAtEye", devNameSpace);
+        VRVector3 center = config->getValue("LookAtCenter", devNameSpace);
+        
+        VRVector3 z = eye - center;
+        z = z.normalize();
+        VRVector3 x = up.cross(z);
+        x = x.normalize();
+        VRVector3 y = z.cross(x);
+        
+        VRMatrix4 M1 = VRMatrix4::fromRowMajorElements(x[0], y[0], z[0], 0,
+                                                       x[1], y[1], z[1], 0,
+                                                       x[2], y[2], z[2], 0,
+                                                       0, 0, 0, 1);
+        
+        VRMatrix4 M2 = VRMatrix4::fromRowMajorElements(1, 0, 0, -eye[0],
+                                                       0, 1, 0, -eye[1],
+                                                       0, 0, 1, -eye[2],
+                                                       0, 0, 0, 1);
+        
+        VRMatrix4 lookAtMatrix = M1 * M2;
+        headMatrix = lookAtMatrix.inverse();
+    }
+    else {
+        std::cerr << "Warning : no HeadMatrix defined for " << devNameSpace << std::endl;
+        std::cerr << "Either Define HeadMatrix or LookAtUp, LookAtEye and LookAtCenter" << std::endl;
+        std::cerr << "Using default: " << headMatrix << std::endl;
+    }
+    
+    std::vector<std::string> forwardKeys;
+    forwardKeys.push_back("KbdUp");
+    forwardKeys.push_back("KbdW");
+    forwardKeys = config->getValueWithDefault("ForwardKeys", forwardKeys, devNameSpace);
+    
+    std::vector<std::string> backKeys;
+    backKeys.push_back("KbdDown");
+    backKeys.push_back("KbdZ");
+    backKeys = config->getValueWithDefault("BackKeys", backKeys, devNameSpace);
+    
+    std::vector<std::string> leftKeys;
+    leftKeys.push_back("KbdLeft");
+    leftKeys.push_back("KbdA");
+    leftKeys = config->getValueWithDefault("LeftKeys", leftKeys, devNameSpace);
+    
+    std::vector<std::string> rightKeys;
+    rightKeys.push_back("KbdRight");
+    rightKeys.push_back("KbdS");
+    rightKeys = config->getValueWithDefault("RightKeys", rightKeys, devNameSpace);
+
+    std::vector<std::string> mouseRotKeys;
+    mouseRotKeys.push_back("MouseBtnRight");
+    mouseRotKeys = config->getValueWithDefault("MouseRotationKeys", mouseRotKeys, devNameSpace);
+    
+    VRFakeHeadTrackerDevice *dev = new VRFakeHeadTrackerDevice(trackerName, toggleEvent, tScale, rScale,
+        headMatrix, forwardKeys, backKeys, leftKeys, rightKeys, mouseRotKeys);
+    vrMain->addEventHandler(dev);
+
+    return dev;
+}
+
+  
+} // end namespace
+
+

--- a/src/input/VRFakeHeadTrackerDevice.h
+++ b/src/input/VRFakeHeadTrackerDevice.h
@@ -1,0 +1,96 @@
+/**
+ This file is part of the MinVR Open Source Project, which is developed and
+ maintained collaboratively by the University of Minnesota and Brown University.
+ 
+ Copyright (c) 2016 Regents of the University of Minnesota and Brown University.
+ This software is distributed under the BSD-3 Clause license, which can be found
+ at: MinVR/LICENSE.txt.
+ 
+ Original Author(s) of this File:
+	Dan Keefe, 2017, University of Minnesota
+	
+ Author(s) of Significant Updates/Modifications to the File:
+	...
+ */
+
+#ifndef VRFAKEHEADTRACKERDEVICE_H
+#define VRFAKEHEADTRACKERDEVICE_H
+
+#include <config/VRDataIndex.h>
+#include <config/VRDataQueue.h>
+#include <input/VRInputDevice.h>
+#include <main/VRFactory.h>
+#include <math/VRMath.h>
+
+namespace MinVR {
+
+/** A "virtual input device" that converts mouse and keyboard events into
+    6 Degree-of-Freedom tracker events.  This facilitates debugging
+    VR programs on a desktop computer.  
+ 
+    This UI acts like a first person camera controller, but instead of setting
+    camera parameters directly, it moves a fake VR user's HeadMatrix based on
+    keyboard and mosue input.  Like typical first-person controllers in games,
+    use the arrow keys or A,S,W,Z keys to move around in the virtual world.
+    UP/DOWN and W/Z move forward and back.  LEFT/RIGHT or A/S rotate your body
+    to face left or right.  Clicking and dragging with the right mouse button
+    makes you look around, similar to the mouse-based head movement in games 
+    like minecraft.  Pressing the "1" key on the keyboard, toggles the entire
+    interface on/off.  
+ 
+    Finally, note that all of the keys mentioned above are just defaults.  These
+    can be reconfigured in the config file where the VRFakeHeadTrackerDevice is
+    defined.  Scale factors can also be set in the config file to adjust the
+    sensativity of the mouse-to-tracker movements.  The scale factors are
+    designed so that a default value of 1.0 works well on most machines.
+ */
+class VRFakeHeadTrackerDevice : public VRInputDevice, public VREventHandler {
+public:
+    
+    VRFakeHeadTrackerDevice(const std::string &trackerName,
+                            const std::string &toggleOnOffEventName,
+                            float tScale,
+                            float rScale,
+                            VRMatrix4 initialHeadFrame,
+                            std::vector<std::string> forwardKeys,
+                            std::vector<std::string> backKeys,
+                            std::vector<std::string> leftKeys,
+                            std::vector<std::string> rightKeys,
+                            std::vector<std::string> mouseRotKeys);
+    
+    virtual ~VRFakeHeadTrackerDevice();
+    
+    void onVREvent(const VRDataIndex &eventData);
+
+    void appendNewInputEventsSinceLastCall(VRDataQueue *inputEvents);
+
+    static VRInputDevice* create(VRMainInterface *vrMain, VRDataIndex *config, const std::string &nameSpace);
+    
+private:
+    
+    bool _tracking;
+    std::string _eventName;
+    std::string _toggleEvent;
+    float _tScale;
+    float _rScale;
+    VRMatrix4 _baseHead;
+    VRMatrix4 _addedRot;
+    VRDataQueue _pendingEvents;
+    float _yaw;
+    float _pitch;
+    bool _mouseRotating;
+    float _lastMouseX;
+    float _lastMouseY;
+    
+    std::vector<std::string> _forwardEvents;
+    std::vector<std::string> _backEvents;
+    std::vector<std::string> _leftEvents;
+    std::vector<std::string> _rightEvents;
+    std::vector<std::string> _mouseRotKeys;
+};
+    
+} // end namespace
+
+#endif
+
+

--- a/src/input/VRFakeTrackerDevice.cpp
+++ b/src/input/VRFakeTrackerDevice.cpp
@@ -56,12 +56,9 @@ VRFakeTrackerDevice::VRFakeTrackerDevice(const std::string &trackerName,
                                                  x[2], up[2], forward[2], 0,
                                                  0, 0, 0, 1);
     _transform = VRMatrix4::translation(_statePos) * _stateRot;
-    VRMatrix4 xform  = _transform;
-
-    VRDataIndex di(_eventName);
-    di.addData(_eventName + "/Transform", xform);
+    
+    VRDataIndex di = VRTrackerEvent::createValidDataIndex(_eventName, _transform.toVRFloatArray());
     _pendingEvents.push(di);
-
 }
 
 
@@ -181,8 +178,7 @@ void VRFakeTrackerDevice::onVREvent(const VRDataIndex &eventData)
 
         _transform = VRMatrix4::translation(_statePos) * _stateRot;
 
-        VRDataIndex di(_eventName);
-        di.addData(_eventName + "/Transform", _transform);
+        VRDataIndex di = VRTrackerEvent::createValidDataIndex(_eventName, _transform.toVRFloatArray());
         _pendingEvents.push(di);
       }
 

--- a/src/main/VRMain.cpp
+++ b/src/main/VRMain.cpp
@@ -19,6 +19,7 @@
 #include <display/VRProjectionNode.h>
 #include <display/VRLookAtNode.h>
 #include <display/VRTrackedLookAtNode.h>
+#include <input/VRFakeHandTrackerDevice.h>
 #include <input/VRFakeTrackerDevice.h>
 #include <net/VRNetClient.h>
 #include <net/VRNetServer.h>
@@ -257,7 +258,7 @@ std::string getCurrentWorkingDir()
 
 VRMain::VRMain() : _initialized(false), _config(NULL), _net(NULL), _factory(NULL), _pluginMgr(NULL), _frame(0), _shutdown(false)
 {
-  _config = new VRDataIndex();
+    _config = new VRDataIndex();
 	_factory = new VRFactory();
 	// add sub-factories that are part of the MinVR core library right away
 	_factory->registerItemType<VRDisplayNode, VRConsoleNode>("VRConsoleNode");
@@ -269,7 +270,9 @@ VRMain::VRMain() : _initialized(false), _config(NULL), _net(NULL), _factory(NULL
 	_factory->registerItemType<VRDisplayNode, VRViewportNode>("VRViewportNode");
 	_factory->registerItemType<VRDisplayNode, VRLookAtNode>("VRLookAtNode");
 	_factory->registerItemType<VRDisplayNode, VRTrackedLookAtNode>("VRTrackedLookAtNode");
-  _factory->registerItemType<VRInputDevice, VRFakeTrackerDevice>("VRFakeTrackerDevice");
+
+    _factory->registerItemType<VRInputDevice, VRFakeHandTrackerDevice>("VRFakeHandTrackerDevice");
+    _factory->registerItemType<VRInputDevice, VRFakeTrackerDevice>("VRFakeTrackerDevice");
 
     _pluginMgr = new VRPluginManager(this);
 }

--- a/src/main/VRMain.cpp
+++ b/src/main/VRMain.cpp
@@ -18,8 +18,9 @@
 #include <display/VRViewportNode.h>
 #include <display/VRProjectionNode.h>
 #include <display/VRLookAtNode.h>
-#include <display/VRTrackedLookAtNode.h>
+#include <display/VRHeadTrackingNode.h>
 #include <input/VRFakeHandTrackerDevice.h>
+#include <input/VRFakeHeadTrackerDevice.h>
 #include <input/VRFakeTrackerDevice.h>
 #include <net/VRNetClient.h>
 #include <net/VRNetServer.h>
@@ -269,9 +270,10 @@ VRMain::VRMain() : _initialized(false), _config(NULL), _net(NULL), _factory(NULL
 	_factory->registerItemType<VRDisplayNode, VRStereoNode>("VRStereoNode");
 	_factory->registerItemType<VRDisplayNode, VRViewportNode>("VRViewportNode");
 	_factory->registerItemType<VRDisplayNode, VRLookAtNode>("VRLookAtNode");
-	_factory->registerItemType<VRDisplayNode, VRTrackedLookAtNode>("VRTrackedLookAtNode");
+	_factory->registerItemType<VRDisplayNode, VRHeadTrackingNode>("VRHeadTrackingNode");
 
     _factory->registerItemType<VRInputDevice, VRFakeHandTrackerDevice>("VRFakeHandTrackerDevice");
+    _factory->registerItemType<VRInputDevice, VRFakeHeadTrackerDevice>("VRFakeHeadTrackerDevice");
     _factory->registerItemType<VRInputDevice, VRFakeTrackerDevice>("VRFakeTrackerDevice");
 
     _pluginMgr = new VRPluginManager(this);


### PR DESCRIPTION
fixed a bug in mouse cursor events from glfw that caused a segfault.  re-added a fake tracker device that works well for hand-held trackers rather than head trackers.  fixed a bug in graphics state where the view and proj matrices were getting garbled.  however, this fix uses a copy.  tom's new pointer accessor for the dataindex might be able to be used to avoid the copy, but i don't think those changes are in this branch yet.