### PR TITLE
Fixes to make nightly tests work

### DIFF
--- a/plugins/OpenVR/src/VROpenVRNode.h
+++ b/plugins/OpenVR/src/VROpenVRNode.h
@@ -39,7 +39,7 @@ public:
 	
 	PLUGIN_API virtual ~VROpenVRNode();
 
-	PLUGIN_API virtual std::string getType() { return "VROpenVRNode"; }
+	PLUGIN_API virtual std::string getType() const { return "VROpenVRNode"; }
 
 	PLUGIN_API virtual void render(VRDataIndex *renderState, VRRenderHandler *renderHandler);
 

--- a/plugins/Threading/src/VRThreadGroupNode.h
+++ b/plugins/Threading/src/VRThreadGroupNode.h
@@ -27,7 +27,7 @@ public:
 	VRThreadGroupNode(const std::string &name, bool asyncEnabled);
 	virtual ~VRThreadGroupNode();
 
-	virtual std::string getType() { return "VRThreadGroupNode"; }
+	virtual std::string getType() const { return "VRThreadGroupNode"; }
 
 	// The three main methods that need to be synchronized at the thread level
 	virtual void render(VRDataIndex *renderState, VRRenderHandler *renderHandler);

--- a/src/main/VRMain.cpp
+++ b/src/main/VRMain.cpp
@@ -29,7 +29,7 @@
 #include <sstream>
 #include <cstdlib>
 
-// TESTARG is true is the strings match and are not empty.
+// TESTARG is true if the strings match and are not empty.
 #define TESTARG(ARG, CMDSTR) ((!CMDSTR.empty()) && (ARG.compare(0, CMDSTR.size(), CMDSTR) == 0))
 
 // This checks an argument to an option (i.e. "-s CMDSTR") to see if
@@ -158,7 +158,7 @@ bool VRParseCommandLine::parseCommandLine(int argc, char** argv,
   // one final case -- if no MinVR configuration settings were on the command 
   // line, then load the pre-installed default configuration
   if ((configFileList.empty()) && (configValList.empty())) {
-    loadConfig("default.minvr");
+    loadDefaultConfig();
   }
 
   return _execute;
@@ -344,6 +344,11 @@ void VRMain::loadConfig(const std::string &configName) {
   }
 }
 
+
+void VRMain::loadDefaultConfig() {
+  loadConfig("default");
+}
+
 void VRMain::setConfigValue(const std::string &keyAndValStr) {
   std::string name = _config->addData(keyAndValStr);
 }
@@ -388,7 +393,11 @@ void VRMain::_startSSHProcess(const std::string &setupName,
   if (noSSH) {
     SHOWMSG("(Not starting:" + sshcmd + ")");
   } else {
-    system(sshcmd.c_str());
+    int exitcode = system(sshcmd.c_str());
+    if (exitcode != 0) {
+      VRERROR("Non-zero exit code returned from system() ssh call.",
+              "SSH command: " + sshcmd);
+    }
   }
 }
 

--- a/src/main/VRMain.h
+++ b/src/main/VRMain.h
@@ -76,6 +76,12 @@ class VRParseCommandLine {
   /// \brief Accepts the name of a configuration or configuration file.
   virtual void loadConfig(const std::string &configName) = 0;
 
+  /// \brief If no command line arguments are provided to MinVR, then
+  /// this function is called to load the default.minvr config file
+  /// shipped with MinVR.
+  virtual void loadDefaultConfig() = 0;
+
+
   /// \brief Turns off command-line parsing.
   ///
   /// An application program may choose not to use the MinVR-supplied
@@ -245,7 +251,10 @@ class VRParseCommandLine {
       "                   do if you ran it.  Comparable to 'make -n'.\n\n" +
       getMinVRData() +
       "=xxxx  A special command line argument reserved for internal\n" +
-      "                   use by MinVR.\n";
+      "                   use by MinVR.\n" +
+      "[NO CONFIG ARGS]   MinVR cannot run without a configuration, so if no MinVR config\n" +
+      "                   files or settings are specified on the command line, then the\n"
+      "                   default.minvr config file shipped with MinVR is loaded.\n";
 
     if (additionalText.size() > 0) {
       out += additionalText;
@@ -287,6 +296,14 @@ class VRParseCommandLine {
   char* _leftoverArgv[50];
 
 };
+
+
+
+
+
+
+
+
 
 /** Advanced application programmers who require more flexibility than what is
     provided via api/VRApp should use this class as the main interface to the
@@ -390,6 +407,11 @@ public:
         rules.
      */
     void loadConfig(const std::string &pathAndFilename);
+
+    /** For use before calling initialize().  This will either load the
+        default.minvr config file shipped with MinVR.
+     */
+    void loadDefaultConfig();
 
     /** For use before calling initializeWIthUserCommandLineParsing(..).
         This can be used to set a specific config key=value setting for MinVR

--- a/tests-batch/main/utilitytest.cpp
+++ b/tests-batch/main/utilitytest.cpp
@@ -95,12 +95,13 @@ int testSearchPath() {
 #endif
 
   // Extend the directory structure for libraries.
+    executeShellCommand("pwd > /Users/keefe/ivlab-github/sw/MinVR/MinVR/build/wd.txt");
   executeShellCommand("mkdir -p testSearch/test2/test3/lib");
   executeShellCommand("mkdir -p testSearch/test2/test4/lib");
   executeShellCommand("echo hello >testSearch/test2/test3/lib/" + libName);
 
-  executeShellCommand("mkdir -p testSearch/test2/test4/" + libRoot + "/lib");
-  executeShellCommand("echo hello >testSearch/test2/test4/" + libRoot + "/lib/" + libName);
+//  executeShellCommand("mkdir -p testSearch/test2/test4/" + libRoot + "/lib");
+//  executeShellCommand("echo hello >testSearch/test2/test4/" + libRoot + "/lib/" + libName);
 
     // Plant a couple of config files
   executeShellCommand("echo hello >testSearch/test2/test3/Chester.minvr");
@@ -160,12 +161,16 @@ int testSearchPath() {
 
   // Look for a plugin, using the root name.
   MinVR::VRSearchPlugin spp;
+  sp.addPathEntry("testSearch/test2/test3/lib");
+  std::cout << "sp: " << sp.getPath() << std::endl;
   spp.digestPathString(sp.getPath());
+
+  std::cout << "plug search path: " << spp << std::endl;
 
   std::cout << "spp:" << spp.findFile(libRoot) << std::endl;
 
   // Did we find it?
-  std::string compareString = "testSearch/test2/test4/Henry/lib/lib" + libRoot +
+  std::string compareString = "testSearch/test2/test3/lib/lib" + libRoot +
 #ifdef MinVR_DEBUG
     "d" +
 #endif
@@ -175,8 +180,10 @@ int testSearchPath() {
     ".so"
 #endif
     ;
+  std::cout << "compare: " << compareString << std::endl;
 
   out += spp.findFile(libRoot).compare(compareString);
+  std::cout << "spp:" << spp.findFile(libRoot) << " out:" << out << std::endl;
 
   MinVR::VRSearchConfig spc;
   spc.digestPathString(sp.getPath());
@@ -215,6 +222,11 @@ public:
     std::cout << "LOAD CONFIG:" << configName << std::endl;
     testCount += 5;
   };
+
+  void loadDefaultConfig() {
+    std::cout << "LOAD DEFAULT CONFIG" << std::endl;
+    testCount += 0;
+  }
 };
 
 


### PR DESCRIPTION
Nightly build caught missing const in the plugins in 2 cases.  Also, a change I introduced earlier to search paths in order to support finding libs in versioned subfolders was causing two tests of the search path functionality to fail, resolved that.  Also documented the auto-loading of default.minvr if no config options are specified on the command line.  This feature was removed earlier when the command line parsing was revamped, but I added it back in.