### PR TITLE
typos in UseFreeGLUT.cmake and VRSearchPath.cpp

### DIFF
--- a/cmake/UseFreeGLUT.cmake
+++ b/cmake/UseFreeGLUT.cmake
@@ -1,9 +1,9 @@
-# This file is part of the MinVR cmake build system.  
+# This file is part of the MinVR cmake build system.
 # See the main MinVR/CMakeLists.txt file for authors, copyright, and license info.
 #
 # Tries to find a pre-installed version of FreeGLUT on this system using find_package().
 # Case 1: If found, then the script uses target_link_library() to link it to your target.
-# Case 2: If not found and AUTOBUILD_DEPENDENCIES is ON, then the script immediately 
+# Case 2: If not found and AUTOBUILD_DEPENDENCIES is ON, then the script immediately
 # downloads, builds, and installs the FreeGLUT library to the location specifed by
 # CMAKE_INSTALL_PREFIX. Then, it tries find_package() again and links to the newly install
 # library.
@@ -11,14 +11,14 @@
 # fatal error.
 
 # Usage: In your CMakeLists.txt, somewhere after you define the target that depends
-# on the FreeGLUT library (typical with something like add_executable(${PROJECT_NAME} ...) 
+# on the FreeGLUT library (typical with something like add_executable(${PROJECT_NAME} ...)
 # or add_library(${PROJECT_NAME} ...)), add the following two lines:
 
 #    include(UseFreeGLUT)
 #    UseFreeGLUT(${PROJECT_NAME} PRIVATE)
 
 # The second argument can be either PUBLIC, PRIVATE, or INTERFACE, following the keyword
-# usage described here: 
+# usage described here:
 # https://cmake.org/cmake/help/latest/command/target_include_directories.html
 
 
@@ -39,7 +39,7 @@ macro(UseFreeGLUT YOUR_TARGET INTERFACE_PUBLIC_OR_PRIVATE)
     find_package(FreeGLUT)
 
     # Case 1: Already installed on the system
-    if (${FreeGLUT_FOUND})
+    if (${FREEGLUT_FOUND})
 
         message(STATUS "Ok: FreeGLUT Found.")
         message(STATUS "FreeGLUT headers: ${FREEGLUT_INCLUDE_DIR}")

--- a/src/main/VRSearchPath.cpp
+++ b/src/main/VRSearchPath.cpp
@@ -44,13 +44,13 @@ std::string VRSearchPath::findFile(const std::string &desiredFile) {
 
   // If this is an absolute path name (starts with a /), just return
   // the file name intact, if it exists.
-  if ((desiredFile[0] == '/') && (_open(desiredFile.c_str(), O_RDONLY) >= 0))
+  if ((desiredFile[0] == '/') && (open(desiredFile.c_str(), O_RDONLY) >= 0))
     return desiredFile;
 
   for (std::list<std::string>::iterator it = _searchPath.begin();
        it != _searchPath.end(); it++) {
     std::string testFile = _selectFile(desiredFile, (*it));
-    if (_open(testFile.c_str(), O_RDONLY) >= 0)
+    if (open(testFile.c_str(), O_RDONLY) >= 0)
       return testFile;
   }
   return "";
@@ -67,15 +67,15 @@ std::string VRSearchPath::getPath() const {
 }
 
 std::string VRSearchPath::getFullFilenames(const std::string &desiredFile) const {
-    
+
     std::string out;
     for (std::list<std::string>::const_iterator it = _searchPath.begin();
          it != _searchPath.end(); it++)
         out += _selectFile(desiredFile, (*it)) + ":";
-    
+
     return out.substr(0, out.length() - 1);
 }
-    
+
 ///
 // Here is the search path order that MinVR searches for plugins:
 //


### PR DESCRIPTION
Hi All:  What's with the change of 'open' to '_open' in VRSearchPath? Is that a Win thing? If so, perhaps it needs to be surrounded with an ifdef Win or something?

Also fixes a typo in UseFreeGLUT.cmake.  That should be all. I don't know why my editor seems to change the newlines, but there are just those two typos, and please ignore the rest.