### PR TITLE
Comm standards

### DIFF
--- a/src/config/VRDataIndex.h
+++ b/src/config/VRDataIndex.h
@@ -472,23 +472,23 @@ public:
   /// \param value The VR core type data value to store under the given key.
   std::string addData(const std::string &key, VRInt value);
 
-  /// \copydoc VRDataIndex::addData(const std::string,VRInt)
+  /// \copydoc VRDataIndex::addData(const std::string &key, VRInt value);
   std::string addData(const std::string &key, VRFloat value);
 
-  /// \copydoc VRDataIndex::addData(const std::string,VRInt)
+  /// \copydoc VRDataIndex::addData(const std::string &key, VRInt value);
   std::string addData(const std::string &key, VRString value);
 
-  /// \copydoc VRDataIndex::addData(const std::string,VRInt)
+  /// \copydoc VRDataIndex::addData(const std::string &key, VRInt value);
   std::string addData(const std::string &key, VRIntArray value);
 
-  /// \copydoc VRDataIndex::addData(const std::string,VRInt)
+  /// \copydoc VRDataIndex::addData(const std::string &key, VRInt value);
   std::string addData(const std::string &key, VRFloatArray value);
 
-  /// \copydoc VRDataIndex::addData(const std::string,VRInt)
+  /// \copydoc VRDataIndex::addData(const std::string &key, VRInt value);
   std::string addData(const std::string &key, VRStringArray value);
 
 
-  /// \copydoc VRDataIndex::addData(const std::string,VRInt)
+  /// \copydoc VRDataIndex::addData(const std::string &key, VRInt value);
   ///
   /// There is a semantic difference between addData() for a primitive
   /// value and addData() for a container.  One creates an object of
@@ -702,8 +702,12 @@ public:
   /// (VRCORETYPE_CONTAINER).
   ///
   /// \param key Can be a full key (namespace + data field name) or just a
-  /// namespace.
+  /// data name.
   /// \param nameSpace The (optional) namespace in which to look for key.
+  /// \param inherit If this is false, the function will only succeed
+  /// if the specified key is found within the given nameSpace.
+  /// Otherwise, it will search in parent nameSpaces for the matching
+  /// key.  (Default: true)
   VRCORETYPE_ID getType(const std::string &key,
                         const std::string nameSpace = "",
                         const bool inherit = true) const {
@@ -727,6 +731,10 @@ public:
   /// \param key Can be a full name (namespace + data field name) or just a
   /// namespace.
   /// \param nameSpace The (optional) container in which to look for key.
+  /// \param inherit If this is false, the function will only succeed
+  /// if the specified key is found within the given nameSpace.
+  /// Otherwise, it will search in parent nameSpaces for the matching
+  /// key.  (Default: true)
   std::string getTypeString(const std::string key,
                             const std::string nameSpace = "",
                             const bool inherit = true) const {
@@ -749,6 +757,13 @@ public:
   ///
   /// Returns the fully qualified name of the specified value, starting with
   /// the root namespace.
+  /// \param key Can be a full key (namespace + data field name) or just a
+  /// data name.
+  /// \param nameSpace The (optional) namespace in which to look for key.
+  /// \param inherit If this is false, the function will only succeed
+  /// if the specified key is found within the given nameSpace.
+  /// Otherwise, it will search in parent nameSpaces for the matching
+  /// key.  (Default: true)
   std::string getFullKey(const std::string &key,
                          const std::string nameSpace = "",
                          const bool inherit = true) const;
@@ -780,8 +795,13 @@ public:
 
 
   /// \brief Returns true if the specified name exists in the index.
-  /// \param keyOrScope Can be a full name (namespace + data field name) or just a
-  /// namespace.
+  /// \param key Can be a full key (namespace + data field name) or just a
+  /// data name.
+  /// \param nameSpace The (optional) namespace in which to look for key.
+  /// \param inherit If this is false, the function will only succeed
+  /// if the specified key is found within the given nameSpace.
+  /// Otherwise, it will search in parent nameSpaces for the matching
+  /// key.  (Default: true)
   bool exists(const std::string &key,
               const std::string nameSpace = "",
               const bool inherit = true) const {
@@ -1224,16 +1244,37 @@ private:
   ///  ~~~
   ///  const_cast<VRDataIndex*>(this)->_getEntry(...)
   ///  ~~~
+  /// \param key Can be a full key (namespace + data field name) or just a
+  /// data name.
+  /// \param nameSpace The (optional) namespace in which to look for key.
+  /// \param inherit If this is false, the function will only succeed
+  /// if the specified key is found within the given nameSpace.
+  /// Otherwise, it will search in parent nameSpaces for the matching
+  /// key.  (Default: true)
   VRDataMap::iterator _getEntry(const std::string &key,
                                 const std::string nameSpace = "",
                                 const bool inherit = true);
 
   // Returns a pointer to the value with a given name (and namespace)
+  /// \param key Can be a full key (namespace + data field name) or just a
+  /// data name.
+  /// \param nameSpace The (optional) namespace in which to look for key.
+  /// \param inherit If this is false, the function will only succeed
+  /// if the specified key is found within the given nameSpace.
+  /// Otherwise, it will search in parent nameSpaces for the matching
+  /// key.  (Default: true)
   VRDatumPtr _getDatum(const std::string &key,
                        const std::string nameSpace = "",
                        const bool inherit = true);
 
   // Returns a pointer to the value with a given name (and namespace)
+  /// \param key Can be a full key (namespace + data field name) or just a
+  /// data name.
+  /// \param nameSpace The (optional) namespace in which to look for key.
+  /// \param inherit If this is false, the function will only succeed
+  /// if the specified key is found within the given nameSpace.
+  /// Otherwise, it will search in parent nameSpaces for the matching
+  /// key.  (Default: true)
   const VRDatumPtr _getDatum(const std::string &key,
                              const std::string nameSpace = "",
                              const bool inherit = true) const;

--- a/src/display/VRDisplayNode.h
+++ b/src/display/VRDisplayNode.h
@@ -18,11 +18,76 @@
 
 namespace MinVR {
 
-/** VRDisplayNode is an abstract base class that can be inherited to
-    create a different types of displays.
- */
-
 class VRMainInterface;
+
+/// \brief VRDisplayNode is an abstract base class that can be inherited to
+///    create different types of display nodes.
+///
+/// Use VRDisplayNode to create new components for a render tree.
+/// This is a structure that MinVR uses to control the context within
+/// which the user's render function is called.  Using the structure
+/// specified in the configuration file, MinVR calls the render
+/// function of the root of the render tree, which adds some
+/// information to the render state and then calls the render function
+/// of its children.  They, in turn, add information to the state and
+/// call the render function of their children, and so on.  The leaf
+/// nodes in the tree call the user's render function, which has
+/// access to all of the information added to the render state by the
+/// nodes above it.
+///
+/// This example of a tree might be used for a simple desktop display:
+///
+///   ~~~
+///   Root Window Node > Head Tracking Node > Projection Node
+///   ~~~
+///
+/// The root node adds some display data to the render function, and
+/// passes it to a Head Tracking Node, which adds the camera matrix to
+/// the render state and passes it to a projection node, which adds a
+/// projection matrix, before calling the user's render function.
+///
+/// Another example, showing a branch in the tree for a stereo view:
+///
+///   ~~~
+///   Root Node > Head Tracking Node > Stereo Node > Left Projection Node
+///                                                > Right Projection Node
+///   ~~~
+///
+/// This is the same situation as above, but the stereo node moves the
+/// eye position it gets from the Head Tracking Node slightly to the
+/// left or the right before calling the render functions for each of
+/// its two children nodes.
+///
+/// ## STANDARDS
+///
+/// The render tree structure is a flexible way to control the context
+/// within which a user's render function is executed, but if you are
+/// writing a new node, life will be better for everyone if you can
+/// make your node conform to existing naming and data type standards.
+/// This will allow other (possibly existing) nodes to understand your
+/// node's data seamlessly.
+///
+/// These are the data names and types currently in use for various
+/// graphic functions.  If you can find the data you need in this
+/// list, you will also find the name under which it is likely to be
+/// filed.  Again, life will be better for everyone if you use these
+/// names wherever possible.
+///
+/// Name       |   Type           |   Data
+/// -----------|------------------|-------------
+/// WindowX    | VRInt            | X coordinate of upper-left window position in pixels.
+/// WindowY    | VRInt            | Y coordinate of upper-left window position in pixels.
+/// WindowWidth| VRInt            | Width of the window in pixels.
+/// WindowHeight| VRInt            | Height of the window.
+/// FrameBufferWidth | VRInt      | Width of the frame buffer in pixels.
+/// FrameBufferHeight | VRInt      | Height of the frame buffer in pixels.
+/// SharedContextId | VRInt        | ??
+/// WindowID    |   VRInt          | ??
+/// HeadMatrix | VRFloatArray(16) | 4x4 column-major pose matrix showing the pose of the user's head.
+/// CameraMatrix | VRFloatArray(16)| 4x4 column-major pose matrix showing the pose of the camera.  This will be related to the head matrix, but will be different by half the eye separation.
+/// ProjectionMatrix | VRFloatArray(16)| 4x4 column-major projection matrix.
+///
+
 
 class VRDisplayNode {
 public:

--- a/src/input/VRFakeTrackerDevice.h
+++ b/src/input/VRFakeTrackerDevice.h
@@ -28,7 +28,7 @@ namespace MinVR {
 /** A "virtual input device" that converts mouse and keyboard events into 6
     Degree-of-Freedom tracker events.  This facilitates debugging VR programs
     on a desktop computer.  You can set up any number of devices, with
-    different names.  The events will be issued as <name>_Move events.  So if
+    different names.  The events will be issued as "name"_Move events.  So if
     your fake tracker is called "Head", it will issue "Head_Move" events.  A
     keyboard event is nominated to turn on and off the various trackers.
 

--- a/src/input/VRInputDevice.h
+++ b/src/input/VRInputDevice.h
@@ -5,12 +5,102 @@
 #include <config/VRDataIndex.h>
 #include <config/VRDataQueue.h>
 
-/** Abstract base class for Input Devices.  Input devices are polled once per frame by
-	VRMain and should return any new events generated since the last call.
- */
-
 namespace MinVR {
 
+/// \brief Abstract base class for Input Devices.
+///
+/// Input devices are polled once per frame by VRMain and should
+///	return any new events generated since the last call.
+///
+/// MinVR supports a flexible event interface, where events can have
+/// any name and contain any data.  However, to maintain compatibility
+/// with other MinVR devices, and so that event handlers can be
+/// developed in polynomial time, here is a list of common event types
+/// and the data that belong to them.  If you are defining a new input
+/// device, and want to support existing software, try to use an event
+/// that conforms to the requirements set out here.
+///
+/// Events themselves are instantiated with the VREvent type, which is
+/// just a typedef synonym for VRDataIndex.
+///
+/// All events will have a "name" and a "type".  The name is held in
+/// the VREvent name field, and can be returned with event.getName().
+/// The type is a string stored in the event as EventType, just the way
+/// other data is stored there.
+///   ~~~
+///   VREvent event("Head_Move");
+///   std::string name = event.getName();
+///   event.addData("EventType", "TrackerMove");
+///   event.addData("Transform", headMatrix);
+///   ~~~
+///
+/// ## EVENT STANDARDS
+///
+/// Life will be better for all concerned if you can use one of the
+/// event types and names specified here.  Obviously new devices are
+/// going to require new names, but these are the names that existing
+/// software will expect to see so if you can fit your needs into this
+/// framework, it will be compatible with other work.  The list below
+/// is of event types, with the event names listed within.
+///
+/// ### AnalogUpdate
+///
+/// Use the AnalogUpdate type for analog values, transmitted as VRFloats.
+///
+/// #### FrameStart
+///
+/// The FrameStart event is a heartbeat event, issued at regular
+/// intervals by the MinVR software, for animation purposes.  It uses
+/// the type AnalogUpdate.
+///
+/// Contains   |    Type    |   What is it?
+/// -----------|------------|-------------------
+/// AnalogValue| VRFloat    | Number of seconds
+/// ElapsedSeconds| VRFloat | Synonym for AnalogValue
+///
+/// Example:
+///   ~~~
+///   FrameStart
+///   | AnalogValue = 10.598754 (float)
+///   | ElapsedSeconds = 10.598754 (float)
+///   | EventType = AnalogUpdate (string)
+///   ~~~
+///
+/// ### ButtonDown / ButtonUp
+///
+/// Use these for keyboard events.  The keyboard events have names
+/// like "Kbdr_Down" and "Kbdr_Up" for pressing and releasing the
+/// "r" key.
+///
+/// Contains   |    Type    |   What is it?
+/// -----------|------------|-------------------
+/// ButtonState| VRInt      | 0 for up, 1 for down.
+///
+/// ### CursorMove
+///
+/// Reports the location of a 2D cursor on a screen.
+///
+/// #### Mouse_Move
+///
+/// Indicates the mouse moved on a desktop.
+///
+/// Contains   |    Type    |   What is it?
+/// -----------|------------|-------------------
+/// Position   | VRFloatArray(2) | mouse position in pixel coordinates
+/// NormalizedPosition | VRFloatArray(2) | mouse position with coordinates ranging from 0 to 1
+///
+///
+/// ### TrackerMove
+///
+/// Provides the 4x4 matrix transform to indicate the pose of a
+/// tracker.  This is used in Head_Move events and Wand_Move events.
+/// Systems with multiple wands will typically use events called
+/// Wand0_Move and Wand1_Move and so on.
+///
+/// Contains   |    Type    |   What is it?
+/// -----------|------------|-------------------
+/// Transform  | VRFloatArray(16) | The 4x4 pose matrix, in column-major form.
+///
 class VRInputDevice {
 public:
 	virtual ~VRInputDevice() {}

--- a/src/main/VRError.h
+++ b/src/main/VRError.h
@@ -26,7 +26,7 @@
 /// of advice about what a user might do to address the error or
 /// warning issued.
 ///
-/// If you use them with the handy-dandy #defines here, you'll also
+/// If you use them with the handy-dandy \#defines here, you'll also
 /// get the file and where the error is issued (which is not the same
 /// as where it happened, of course), and maybe even the function
 /// name, depending on your compiler.
@@ -62,7 +62,7 @@ class VRError: public std::exception {
 public:
   /// Constructor.  Several of the calling values are meant to be picked up
   /// through preprocessor directives, so should be accompanied by a matching
-  /// #define to put them in.
+  /// \#define to put them in.
   ///  \param whatMsg The error message: what went wrong.  For example,
   ///  "file not found."
   ///  \param adviceMsg Some advice about what the user might do about this.


### PR DESCRIPTION
I would like to start the discussion about how to maintain and enforce standards for event construction and display node / render state discussion.  This pull request adds a list of event types and names and their contents to the VRInputDevice.h file, and the same kind of thing to the VRDisplayNode.h file. 

Not sure these are the best places, or that the standards are mutually agreeable, but we need to settle on something and this is my first stab at it.