### PR TITLE
Changed VRGraphicsState to retrieve the matrix and vector data directly from the VRDataIndex

### DIFF
--- a/src/api/impl/VRGraphicsState.cpp
+++ b/src/api/impl/VRGraphicsState.cpp
@@ -41,24 +41,24 @@ const VRDataIndex& VRGraphicsState::index() const {
 
 const float * VRGraphicsState::getProjectionMatrix() const {
     if (_index.exists("ProjectionMatrix")) {
-        VRFloatArray mat = _index.getValue("ProjectionMatrix");
-        std::copy(mat.begin(), mat.end(), projMat);
+        const VRFloatArray* mat = (const VRFloatArray*)_index.getValue("ProjectionMatrix");
+        return &(*mat)[0];
     }
     return projMat;
 }
 
 const float * VRGraphicsState::getViewMatrix() const {
     if (_index.exists("ViewMatrix")) {
-        VRFloatArray mat = _index.getValue("ViewMatrix");
-        std::copy(mat.begin(), mat.end(), viewMat);
+        const VRFloatArray* mat = (const VRFloatArray*)_index.getValue("ViewMatrix");
+        return &(*mat)[0];
     }
     return viewMat;
 }
 
 const float * VRGraphicsState::getCameraPos() const {
     if (_index.exists("EyePosition")) {
-        VRFloatArray mat = _index.getValue("EyePosition");
-        std::copy(mat.begin(), mat.end(), eyePos);
+        const VRFloatArray* vec = (const VRFloatArray*)_index.getValue("EyePosition");
+        return &(*vec)[0];
     }
     return eyePos;
 }


### PR DESCRIPTION
The copy to static variables in the VRGraphicsState was creating race conditions for the multi-threaded solution.  Tom added the ability to retrieve const pointers from the data index, so we should can use them directly now if they exist.