### PR TITLE
fixes to pass tests on windows

### DIFF
--- a/src/config/VRDataQueue.cpp
+++ b/src/config/VRDataQueue.cpp
@@ -115,14 +115,15 @@ void VRDataQueue::clear() {
 long long VRDataQueue::makeTimeStamp() {
 
 #ifdef WIN32
-	LARGE_INTEGER frequency;        // ticks per second
 	LARGE_INTEGER t1;
-	QueryPerformanceFrequency(&frequency);
 
-	// start timer
-	QueryPerformanceCounter(&t1);
+	FILETIME ft;
+	GetSystemTimePreciseAsFileTime(&ft); // Requires windows 8 and above. Should give microsecond resolution and be consistent across different machines if they are using a time server.
 
-	long long timeStamp = (t1.QuadPart) * 1000 / frequency.QuadPart + clock();
+	t1.LowPart = ft.dwLowDateTime;
+	t1.HighPart = ft.dwHighDateTime;
+
+	long long timeStamp = t1.QuadPart;
 #else
 
   struct timeval tp;

--- a/src/main/VRMain.cpp
+++ b/src/main/VRMain.cpp
@@ -198,7 +198,7 @@ void VRParseCommandLine::decodeMinVRData(const std::string &payload) {
 
     //std::cout << "processing decoded >" << arg << "<" << std::endl;
 
-    newArgv[newArgc] = new char[arg.size()];
+    newArgv[newArgc] = new char[arg.size()+1];
     strcpy(newArgv[newArgc++], arg.c_str());
   }
 

--- a/src/main/VRMain.cpp
+++ b/src/main/VRMain.cpp
@@ -198,7 +198,7 @@ void VRParseCommandLine::decodeMinVRData(const std::string &payload) {
 
     //std::cout << "processing decoded >" << arg << "<" << std::endl;
 
-    newArgv[newArgc] = new char[arg.size()+1];
+    newArgv[newArgc] = new char[arg.size()+1]; // add one to length to account for null terminator to avoid buffer overrun
     strcpy(newArgv[newArgc++], arg.c_str());
   }
 


### PR DESCRIPTION
Addresses #223 related to adding timestamps for events on Windows.
Fixes a buffer overflow when parsing command line arguments.