### PR TITLE
build fixes for YURT, aid finding OpenGL

### DIFF
--- a/cmake/UseFreeGLUT.cmake
+++ b/cmake/UseFreeGLUT.cmake
@@ -63,6 +63,7 @@ macro(UseFreeGLUT YOUR_TARGET INTERFACE_PUBLIC_OR_PRIVATE)
         MinVRExternalProject_BuildAndInstallNow(
             FreeGLUT
             src
+	    -D_OPENGL_LIB_PATH=${_OPENGL_LIB_PATH} -D_OPENGL_INCLUDE_PATH=${_OPENGL_INCLUDE_PATH}
         )
 
         # Try find_package() again

--- a/cmake/UseGLEW.cmake
+++ b/cmake/UseGLEW.cmake
@@ -57,6 +57,7 @@ macro(UseGLEW YOUR_TARGET INTERFACE_PUBLIC_OR_PRIVATE)
         MinVRExternalProject_BuildAndInstallNow(
             GLEW
             src/build/cmake
+	    -D_OPENGL_LIB_PATH=${_OPENGL_LIB_PATH} -D_OPENGL_INCLUDE_PATH=${_OPENGL_INCLUDE_PATH}
         )
 
         # Try find_package() again

--- a/cmake/UseGLFW.cmake
+++ b/cmake/UseGLFW.cmake
@@ -58,6 +58,7 @@ macro(UseGLFW YOUR_TARGET INTERFACE_PUBLIC_OR_PRIVATE)
         MinVRExternalProject_BuildAndInstallNow(
             GLFW
             src
+	    -D_OPENGL_LIB_PATH=${_OPENGL_LIB_PATH} -D_OPENGL_INCLUDE_PATH=${_OPENGL_INCLUDE_PATH}
         )
 
         # Try find_package() again

--- a/plugins/Scalable/CMakeLists.txt
+++ b/plugins/Scalable/CMakeLists.txt
@@ -60,8 +60,8 @@ endif()
 # the libScalable.
 find_package(LibSCALABLE REQUIRED)
 target_compile_definitions(${PROJECT_NAME} PUBLIC -D_EASYBLENDSDK_LINUX)
-target_include_directories(${PROJECT_NAME} ${LIBSCALABLE_INCLUDE_DIRS})
-target_link_libraries(${PROJECT_NAME} ${LIBSCALABLE_ALL_LIBRARIES})
+target_include_directories(${PROJECT_NAME} PUBLIC ${LIBSCALABLE_INCLUDE_DIRS})
+target_link_libraries(${PROJECT_NAME} PUBLIC ${LIBSCALABLE_ALL_LIBRARIES})
 
 
 # Installation:


### PR DESCRIPTION
Hi All: Because we're constantly doing all-too-sneaky stuff with the OpenGL drivers, the default cmake method for finding the relevant library and include files are not correct over here. The default finder allows you to set _OPENGL_INCLUDE_PATH and _OPENGL_LIB_PATH to fix this, but these values didn't get passed to MinVRExternalProject_BuildAndInstallNow. So I added that for GLEW, GLFW, and FreeGLUT. I don't believe this will impact anyone else.

The other change just adds the PUBLIC keyword to a couple of lines in the Scalable CMakeLists.txt file, where they had been omitted.