### PR TITLE
fixes timestamps for windows 7, although with lower resolution

### DIFF
--- a/src/config/VRDataQueue.cpp
+++ b/src/config/VRDataQueue.cpp
@@ -118,8 +118,22 @@ long long VRDataQueue::makeTimeStamp() {
 	LARGE_INTEGER t1;
 
 	FILETIME ft;
-	GetSystemTimePreciseAsFileTime(&ft); // Requires windows 8 and above. Should give microsecond resolution and be consistent across different machines if they are using a time server.
 
+	// Determine if windows 8 or greater
+	OSVERSIONINFO osvi;
+	ZeroMemory(&osvi, sizeof(OSVERSIONINFO));
+	osvi.dwOSVersionInfoSize = sizeof(OSVERSIONINFO);
+	GetVersionEx(&osvi);
+
+	//https://en.wikipedia.org/wiki/List_of_Microsoft_Windows_versions
+	if (osvi.dwMajorVersion > 6 || (osvi.dwMajorVersion == 6) && (osvi.dwMinorVersion >= 2)) {
+		GetSystemTimePreciseAsFileTime(&ft); // Requires windows 8 and above. Should give microsecond resolution and be consistent across different machines if they are using a time server.
+	}
+	else {
+		GetSystemTimeAsFileTime(&ft);
+	}
+
+	
 	t1.LowPart = ft.dwLowDateTime;
 	t1.HighPart = ft.dwHighDateTime;
 


### PR DESCRIPTION
On windows 7 and lower, this should fall back to just getting an imprecise timestamp. This will make the dataqueue test fail because it is measuring very small timestamp differences, but hopefully in practice things will still be roughly sequential in the queue.

Of course, I don't have a windows 7 machine to test this on  :-)