### PR TITLE
fixed CMakeLists.txt file

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -159,7 +159,6 @@ set(vr_main_cpp
 )
 
 set(vr_main_h
-  ${vr_src_dir}/main/VRAppLauncher.h
   ${vr_src_dir}/main/VRError.h
   ${vr_src_dir}/main/VREventHandler.h
   ${vr_src_dir}/main/VREventInternal.h


### PR DESCRIPTION
Removed the reference to VRAppLauncher.h which no longer exists. See issue #232