### PR TITLE
Fix compile errors due to `using namespace std` no longer being present

### DIFF
--- a/plugins/FREEGLUT/src/VRFreeGLUTInputDevice.cpp
+++ b/plugins/FREEGLUT/src/VRFreeGLUTInputDevice.cpp
@@ -162,7 +162,7 @@ std::string getKeyName(int key, bool isSpecial) {
 				return "Esc";
 
 			default:
-				stringstream s;
+				std::stringstream s;
 				s << (unsigned char) key;
 				return s.str();
 		}

--- a/plugins/OpenVR/src/VROpenVRInputDevice.cpp
+++ b/plugins/OpenVR/src/VROpenVRInputDevice.cpp
@@ -18,7 +18,7 @@
 
 namespace MinVR {
                        
-	VROpenVRInputDevice::VROpenVRInputDevice(vr::IVRSystem *pHMD, string name, VROpenVRNode * node, float deviceUnitsToRoomUnits, VRMatrix4 deviceToRoom) :m_pHMD(pHMD), m_name(name), m_node(node), deviceUnitsToRoomUnits(deviceUnitsToRoomUnits), deviceToRoom(deviceToRoom)
+	VROpenVRInputDevice::VROpenVRInputDevice(vr::IVRSystem *pHMD, std::string name, VROpenVRNode * node, float deviceUnitsToRoomUnits, VRMatrix4 deviceToRoom) :m_pHMD(pHMD), m_name(name), m_node(node), deviceUnitsToRoomUnits(deviceUnitsToRoomUnits), deviceToRoom(deviceToRoom)
 	{
 		updateDeviceNames();
 
@@ -81,13 +81,13 @@ std::string VROpenVRInputDevice::getAxisType(int device, int axis){
 	int32_t type = m_pHMD->GetInt32TrackedDeviceProperty( device, ((vr::ETrackedDeviceProperty) (vr::Prop_Axis0Type_Int32 +  axis)));
 	switch(type){
 		case vr::k_eControllerAxis_None:
-			return "None" + to_string(axis);
+			return "None" + std::to_string(axis);
 		case vr::k_eControllerAxis_TrackPad:
-			return "TrackPad" + to_string(axis);
+			return "TrackPad" + std::to_string(axis);
 		case vr::k_eControllerAxis_Joystick:
-			return "Joystick" + to_string(axis);
+			return "Joystick" + std::to_string(axis);
 		case vr::k_eControllerAxis_Trigger:
-			return "Trigger" + to_string(axis);
+			return "Trigger" + std::to_string(axis);
 	}
 	return "Invalid";
 }


### PR DESCRIPTION
The GLUT plugin currently won't compile because of a missing  "std::" prefix.