### PR TITLE
Fixing OpenVR input exceptions on touch events. 

### DIFF
--- a/plugins/OpenVR/src/VROpenVRInputDevice.cpp
+++ b/plugins/OpenVR/src/VROpenVRInputDevice.cpp
@@ -257,14 +257,14 @@ void VROpenVRInputDevice::processVREvent( const vr::VREvent_t & event ,vr::Track
 	case vr::VREvent_ButtonTouch:
 		{
 			std::string event_name = getDeviceName(event.trackedDeviceIndex) + "_" + getButtonName((vr::EVRButtonId) event.data.controller.button) + "_Touch";
-			VRDataIndex di = VRButtonEvent::createValidDataIndex(event_name, 3);
+			VRDataIndex di = VRButtonEvent::createValidDataIndex(event_name, 1);
 			_events.push_back(di);
 		}
 		break;
 	case vr::VREvent_ButtonUntouch:
 		{
 			std::string event_name = getDeviceName(event.trackedDeviceIndex) + "_" + getButtonName((vr::EVRButtonId) event.data.controller.button) + "_Untouch";
-			VRDataIndex di = VRButtonEvent::createValidDataIndex(event_name, 4);
+			VRDataIndex di = VRButtonEvent::createValidDataIndex(event_name, 0);
 			_events.push_back(di);
 		}
 		break;

--- a/src/api/VRApp.h
+++ b/src/api/VRApp.h
@@ -53,6 +53,7 @@ public:
 
 	virtual void onTrackerMove(const VRTrackerEvent &state) {}
 
+	virtual void onGenericEvent(const VRDataIndex &index) {}
 
 	/** RENDERING CALLBACKS **/
 

--- a/src/api/impl/VRApp.cpp
+++ b/src/api/impl/VRApp.cpp
@@ -76,8 +76,7 @@ public:
             _app->onTrackerMove(VRTrackerEvent(eventData));
         }
         else {
-            VRERROR("VRAppInternal::onVREvent() received an event of unknown type: " + type,
-                    "Perhaps an input device that sends a new type of event was rencently added.");
+			_app->onGenericEvent(eventData);
         }
 	}
 

--- a/src/api/impl/VRButtonEvent.cpp
+++ b/src/api/impl/VRButtonEvent.cpp
@@ -54,20 +54,14 @@ const VRDataIndex& VRButtonEvent::index() const {
 
 VRDataIndex VRButtonEvent::createValidDataIndex(const std::string &eventName, int buttonState) {
     VRDataIndex di(eventName);
-    if (buttonState == 0) {
-        di.addData("EventType", "ButtonUp");
-    }
-    else if (buttonState == 1) {
-        di.addData("EventType", "ButtonDown");
-    }
-    else if (buttonState == 2) {
-        di.addData("EventType", "ButtonRepeat");
+	if (buttonState == 0) {
+		di.addData("EventType", "ButtonUp");
 	}
-	else if (buttonState == 3) {
-		di.addData("EventType", "ButtonTouch");
+	else if (buttonState == 1) {
+		di.addData("EventType", "ButtonDown");
 	}
-	else if (buttonState == 4) {
-		di.addData("EventType", "ButtonUntouch");
+	else if (buttonState == 2) {
+		di.addData("EventType", "ButtonRepeat");
 	}
     else {
         VRERROR("VRButtonEvent cannot create a valid data index because it received an unrecognized value for buttonState.",

--- a/src/display/VRStereoNode.h
+++ b/src/display/VRStereoNode.h
@@ -47,6 +47,9 @@ public:
 
 	static VRDisplayNode* create(VRMainInterface *vrMain, VRDataIndex *config, const std::string &nameSpace);
 
+	void setIOD(float iod) { _iod = iod; }
+	float getIod() const { return _iod; }
+
 protected:
 	void renderOneEye(VRDataIndex *renderState, VRRenderHandler *renderHandler, VREyePosition eye);
 	void setCameraMatrix(VRDataIndex *renderState, VREyePosition eye);

--- a/src/main/VRError.h
+++ b/src/main/VRError.h
@@ -80,6 +80,7 @@ public:
 
     // Convert the line number to a string.
     std::stringstream ss; ss << whereLine; _whereLine = ss.str();
+	std::cerr << _errorMessage() << std::endl;
   };
 
   std::string _errorMessage() const {

--- a/src/main/VRMain.cpp
+++ b/src/main/VRMain.cpp
@@ -1003,7 +1003,30 @@ VRMain::addInputDevice(VRInputDevice* dev) {
 	_inputDevices.push_back(dev);
 }
 
+std::vector<VRDisplayNode*> VRMain::getDisplayNodesByName(std::string name, VRDisplayNode* node)
+{
+	std::vector<VRDisplayNode*> vec;
+	std::vector<VRDisplayNode*> nodes;
+	if (node = nullptr) {
+		nodes = _displayGraphs;
+	}
+	else
+	{
+		nodes = node->getChildren();
+	}
 
+	for (int i = 0; i < nodes.size(); i++)
+	{
+		if (nodes[i]->getName() == name)
+		{
+			vec.push_back(nodes[i]);
+		}
+
+		std::vector<VRDisplayNode*> vec2 = getDisplayNodesByName(name, nodes[i]);
+		vec.insert(vec.end(), vec2.begin(), vec2.end());
+	}
+	return vec;
+}
 
 /**
 void VRMain::removeEventHandler(VREventHandler* eventHandler) {

--- a/src/main/VRMain.h
+++ b/src/main/VRMain.h
@@ -508,7 +508,17 @@ public:
     /// can be used by customized implementations of the mainloop function
     bool getShutdown() const { return _shutdown; }
 
+	/// Provides access to pointers to display nodes based on the type of the node,
+	/// If no node of the requested type is found an empty vector is returned.
+	/// If there are multiple ones with the same type all of them are returned.
+	/// e.g. std::vector<VRStereoNode*> nodes = _main->getDisplayNodesByType<VRStereoNode>();
+	template <class T>
+	std::vector<T*> getDisplayNodesByType(VRDisplayNode* node = nullptr);
 
+	/// Provides access to pointers to display nodes based on the name of the node,
+	/// If no node with the requested name are found an empty vector is returned.
+	/// If there are multiple ones with the same type all of them are returned.
+	std::vector<VRDisplayNode*> getDisplayNodesByName(std::string name, VRDisplayNode* node = nullptr);
 
 
     /***** USED INTERNALLY BY MINVR -- THESE COULD PROBABLY BE MOVED TO AN IMPLEMENTATION FILE *****/
@@ -567,6 +577,37 @@ public:
     VRSearchPlugin                  _pluginSearchPath;
 
     int _frame;
+
+	template <class T>
+	std::vector<T*> VRMain::getDisplayNodesByType(VRDisplayNode* node)
+	{
+
+		std::vector<T*> vec;
+		std::vector<VRDisplayNode*> nodes;
+
+		if (node == nullptr) {
+			nodes = _displayGraphs;
+		}
+		else
+		{
+			nodes = node->getChildren();
+		}
+
+		for (int i = 0; i < nodes.size(); i++)
+		{
+			T* tmp = dynamic_cast<T*>(nodes[i]);
+			if (tmp != nullptr)
+			{
+				vec.push_back(tmp);
+			}
+			std::vector<T*> vec2 = getDisplayNodesByType<T>(nodes[i]);
+			if (!vec2.empty())vec.insert(vec.end(), vec2.begin(), vec2.end());
+		}
+		return vec;
+	}
+
+
+
     bool _shutdown;
 };
 

--- a/src/plugin/VRSharedLibrary.cpp
+++ b/src/plugin/VRSharedLibrary.cpp
@@ -90,10 +90,8 @@ void VRSharedLibrary::load() {
 
 		if (!_lib) {
 
-//#ifdef MinVR_DEBUG
 			VRWARNING("Could not load library: " + _filePath + " - " + error,
-                "This is a harmless warning, unless the library can't be found anywhere else.");
-//#endif
+				"Check if the plugin and all its dependencies are installed correctly.");
 			return;
 
 		}


### PR DESCRIPTION
@BenKnorlein submitted this changes a while ago in the beta branch, but they were never merged into master. I am resubmitting them.

Mouse Touch Events are now Up and Down events and an extra onGenericEvent can be used for events which are not classified.

Added an Error Message to the loading of plugins when it cannot load and changed the default VRError to also print to the command line.
Added 2 functions to VRMain to query the DisplayNodes by either type and name and added a getter and setter for the iod to the stereonode