### PR TITLE
autobuilds fix and update

### DIFF
--- a/cmake/AutoBuildG3D.cmake
+++ b/cmake/AutoBuildG3D.cmake
@@ -11,7 +11,6 @@ AutoBuild_init()
 
 
 
-
 # Usage:
 # AutoBuild_use_package_G3D(
 #    # The 1st argument is required.  It is the name of the target you wish to link this dependency to.
@@ -44,7 +43,7 @@ macro(AutoBuild_use_package_G3D YOUR_TARGET INTERFACE_PUBLIC_OR_PRIVATE)
             AutoBuild_build_and_install_project(
                 ${PACKAGE_NAME}
                 .
-				-DCMAKE_GENERATOR_PLATFORM=${CMAKE_GENERATOR_PLATFORM}
+				-DWITHOUT_FFMPEG=ON -DCMAKE_GENERATOR_PLATFORM=${CMAKE_GENERATOR_PLATFORM}
             )
 
             AutoBuild_find_built_package_module_mode(${PACKAGE_NAME})
@@ -65,21 +64,12 @@ macro(AutoBuild_use_package_G3D YOUR_TARGET INTERFACE_PUBLIC_OR_PRIVATE)
 
         target_include_directories(${YOUR_TARGET} ${INTERFACE_PUBLIC_OR_PRIVATE} ${G3D_INCLUDE_DIR} ${GLG3D_INCLUDE_DIR})
         target_link_libraries(${YOUR_TARGET} PUBLIC debug 
-            ${INTERFACE_PUBLIC_OR_PRIVATE} ${GLG3D_DEBUG_LIBRARIES}
-            ${INTERFACE_PUBLIC_OR_PRIVATE} ${G3D_DEBUG_LIBRARIES}
-			${INTERFACE_PUBLIC_OR_PRIVATE} ${G3D_LIBRARIES}
-			${INTERFACE_PUBLIC_OR_PRIVATE} ${G3D_EXTRA_LIBRARIES}
+            ${INTERFACE_PUBLIC_OR_PRIVATE} ${G3D_LIBRARIES}
         )
 		
 		target_link_libraries(${YOUR_TARGET} PUBLIC optimized  	
-		    ${INTERFACE_PUBLIC_OR_PRIVATE} ${GLG3D_OPT_LIBRARIES}
-		    ${INTERFACE_PUBLIC_OR_PRIVATE} ${G3D_OPT_LIBRARIES}
-			${INTERFACE_PUBLIC_OR_PRIVATE} ${G3D_LIBRARIES}
-			${INTERFACE_PUBLIC_OR_PRIVATE} ${G3D_EXTRA_LIBRARIES}
+		    ${INTERFACE_PUBLIC_OR_PRIVATE} ${G3D_LIBRARIES}
         )
-		
-		
-	
 
         if (${CMAKE_SYSTEM_NAME} MATCHES "Linux")
             find_package(Threads)
@@ -98,4 +88,3 @@ macro(AutoBuild_use_package_G3D YOUR_TARGET INTERFACE_PUBLIC_OR_PRIVATE)
     endif()
 
 endmacro()
-

--- a/cmake/AutoBuildGLEW.cmake
+++ b/cmake/AutoBuildGLEW.cmake
@@ -27,8 +27,10 @@ macro(AutoBuild_use_package_GLEW YOUR_TARGET INTERFACE_PUBLIC_OR_PRIVATE)
 
             message(STATUS "AutoBuild: Beginning download, build, install sequence.")
 			message(STATUS "CMAKE_GENERATOR ${CMAKE_GENERATOR}")
+			message(STATUS "MSVC_VERSION ${MSVC_VERSION}")
 			
-            if(${CMAKE_GENERATOR} STREQUAL "Visual Studio 16 2019" )
+            if((${MSVC_VERSION} GREATER_EQUAL 1910) )
+			   message(STATUS "Getting GLEW support for VS 15.0")   
 			   set(GLEW_URL https://sourceforge.net/projects/glew/files/glew/snapshots/glew-20190928.zip )
 			else()
 			   set(GLEW_URL https://sourceforge.net/projects/glew/files/glew/2.1.0/glew-2.1.0.zip )

--- a/cmake/AutoBuildGLEW.cmake
+++ b/cmake/AutoBuildGLEW.cmake
@@ -17,6 +17,7 @@ include(AutoBuild)
 #
 macro(AutoBuild_use_package_GLEW YOUR_TARGET INTERFACE_PUBLIC_OR_PRIVATE)
     set(PACKAGE_NAME "GLEW")
+	set(GLEW_URL "")
     string(TOUPPER ${PACKAGE_NAME} PACKAGE_NAME_UPPER)
 
     AutoBuild_find_package_module_mode(${PACKAGE_NAME})
@@ -25,10 +26,17 @@ macro(AutoBuild_use_package_GLEW YOUR_TARGET INTERFACE_PUBLIC_OR_PRIVATE)
         if ("${AUTOBUILD_EXECUTE_NOW}")
 
             message(STATUS "AutoBuild: Beginning download, build, install sequence.")
-
+			message(STATUS "CMAKE_GENERATOR ${CMAKE_GENERATOR}")
+			
+            if(${CMAKE_GENERATOR} STREQUAL "Visual Studio 16 2019" )
+			   set(GLEW_URL https://sourceforge.net/projects/glew/files/glew/snapshots/glew-20190928.zip )
+			else()
+			   set(GLEW_URL https://sourceforge.net/projects/glew/files/glew/2.1.0/glew-2.1.0.zip )
+			endif()
+			
             AutoBuild_download_project( 
                 ${PACKAGE_NAME}
-                URL https://sourceforge.net/projects/glew/files/glew/2.1.0/glew-2.1.0.zip
+				URL ${GLEW_URL}
             )
 
             AutoBuild_build_and_install_project(


### PR DESCRIPTION
fixed AutoBuildG3D to avoid linking against FFMPEG. Updated AutoBuildGlew to support visual studio 2019